### PR TITLE
QA-1422: Updated TestRunner validation to check cluster specification.

### DIFF
--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -159,7 +159,7 @@ public class TestRunner {
     }
 
     // update any Kubernetes properties specified by the test configuration
-    if (!config.server.skipKubernetes) {
+    if (!config.server.skipKubernetes && config.disruptiveScript != null) {
       KubernetesClientUtils.buildKubernetesClientObjectWithClientKey(
           config.server, config.application);
       modifyKubernetesPostDeployment();

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -159,7 +159,7 @@ public class TestRunner {
     }
 
     // update any Kubernetes properties specified by the test configuration
-    if (!config.server.skipKubernetes && config.disruptiveScript != null) {
+    if (!config.server.skipKubernetes) {
       KubernetesClientUtils.buildKubernetesClientObjectWithClientKey(
           config.server, config.application);
       modifyKubernetesPostDeployment();

--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -112,8 +112,7 @@ public class ServerSpecification implements SpecificationInterface {
   public void validate() {
     if (!skipKubernetes) {
       if (cluster == null) {
-        throw new IllegalArgumentException(
-                "Cluster Specification must be defined");
+        throw new IllegalArgumentException("Cluster Specification must be defined");
       }
       cluster.validate();
       if (testRunnerK8SServiceAccount == null) {
@@ -129,8 +128,7 @@ public class ServerSpecification implements SpecificationInterface {
       deploymentScript.validate();
     }
     if (testRunnerServiceAccount == null) {
-      throw new IllegalArgumentException(
-              "Test Runner Service Account must be defined");
+      throw new IllegalArgumentException("Test Runner Service Account must be defined");
     }
     testRunnerServiceAccount.validate();
 

--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -111,6 +111,10 @@ public class ServerSpecification implements SpecificationInterface {
    */
   public void validate() {
     if (!skipKubernetes) {
+      if (cluster == null) {
+        throw new IllegalArgumentException(
+                "Cluster Specification must be defined");
+      }
       cluster.validate();
       if (testRunnerK8SServiceAccount == null) {
         throw new IllegalArgumentException(
@@ -124,7 +128,10 @@ public class ServerSpecification implements SpecificationInterface {
       }
       deploymentScript.validate();
     }
-
+    if (testRunnerServiceAccount == null) {
+      throw new IllegalArgumentException(
+              "Test Runner Service Account must be defined");
+    }
     testRunnerServiceAccount.validate();
 
     if (bufferClientServiceAccount != null) {


### PR DESCRIPTION
Just a minor fix so GH action can run both resiliency tests and other test types.

Additional notes: The main purpose of this PR is to enable different types of tests (Integration / Resiliency) to use the same test configuration file. The assumption is that Integration tests do not need the `KubernetesClientUtils` to manipulate a cluster. So if developers have only integration tests in mind, the test config specification they create might not have the cluster specification and test runner validation will fail. If the assumption wasn't correct (as Mariko points out) then we need to figure out what would be the best way to use one test configuration for all test types.

Added @gjuggler to this Pull Request. Since Mariko is on vacation, I would like Dan and Greg to review and give this ticket a second eye. I can loop Mariko in once she's back from vacation.
