### PR TITLE
QA-1438: Extend Test Runner Framework to support MCTerra Component Version ConfigMap.

### DIFF
--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -320,6 +320,7 @@ public final class KubernetesClientUtils {
    */
   private static void importComponentVersions() {
     try {
+      // Get the Terra Component Version ConfigMap for the namespace.
       V1ConfigMap config =
           getKubernetesClientCoreObject()
               .readNamespacedConfigMap("terra-component-version", namespace, null, null, null);
@@ -425,17 +426,6 @@ public final class KubernetesClientUtils {
                   namespace, null, null, null, null, null, null, null, null, null);
     }
     return list.getItems();
-  }
-
-  /**
-   * Get the Kubernetes ConfigMap identified by the name argument.
-   *
-   * @param name the name of the Kubernetes ConfigMap
-   * @return a V1ConfigMap object
-   */
-  public static V1ConfigMap getComponentVersionConfigMap(String name) throws ApiException {
-    return getKubernetesClientCoreObject()
-        .readNamespacedConfigMap(name, namespace, null, null, null);
   }
 
   /**

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -84,6 +84,14 @@ public final class KubernetesClientUtils {
     return kubernetesClientAppsObject;
   }
 
+  /**
+   * This method returns the component versions of all MCTerra Services as a map of maps.
+   * The Component Version ConfigMap for the target namespace is the source of truth.
+   *
+   * The state of a deployed MCTerra Service can be uniquely identified by the set
+   * of component version keys present in the map nested inside the top-level map.
+   *
+   */
   public static Map<String, Map<String, String>> getComponentVersions() {
     return componentVersions;
   }

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -82,6 +82,10 @@ public final class KubernetesClientUtils {
     return kubernetesClientAppsObject;
   }
 
+  public static Map<String, Map<String, String>> getComponentVersions() {
+    return componentVersions;
+  }
+
   /**
    * Build the singleton Kubernetes client objects. This method should be called once at the
    * beginning of a test run, and then all subsequent fetches should use the getter methods instead.

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -85,14 +85,15 @@ public final class KubernetesClientUtils {
   }
 
   /**
-   * This method returns the component versions of all MCTerra Services as a map of maps.
-   * The Component Version ConfigMap for the target namespace is the source of truth.
+   * This method returns the component versions of all MCTerra Services as a map of maps. The
+   * Component Version ConfigMap for the target namespace is the source of truth.
    *
-   * The state of a deployed MCTerra Service can be uniquely identified by the set
-   * of component version keys present in the map nested inside the top-level map.
-   *
+   * <p>The state of a deployed MCTerra Service can be uniquely identified by the set of component
+   * version keys present in the map nested inside the top-level map.
    */
   public static Map<String, Map<String, String>> getComponentVersions() {
+    // Import MCTerra Component versions from ConfigMap and outputs JSON-ready format
+    importComponentVersions();
     return componentVersions;
   }
 
@@ -305,9 +306,6 @@ public final class KubernetesClientUtils {
 
     kubernetesClientCoreObject = new CoreV1Api();
     kubernetesClientAppsObject = new AppsV1Api();
-
-    // Import MCTerra Component versions from ConfigMap and outputs JSON-ready format
-    importComponentVersions();
   }
 
   /**

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -460,7 +460,7 @@ public class TestRunner {
   private static final String renderedConfigFileName = "RENDERED_testConfiguration.json";
   private static final String userJourneyResultsFileName = "RAWDATA_userJourneyResults.json";
   private static final String runSummaryFileName = "SUMMARY_testRun.json";
-  private static final String terraVersionFileName = "TERRA_componentVersion.json";
+  private static final String envVersionFileName = "ENV_componentVersion.json";
 
   protected void writeOutResults(String outputParentDirName) throws IOException {
     // use Jackson to map the object to a JSON-formatted text block
@@ -490,7 +490,7 @@ public class TestRunner {
     File userJourneyResultsFile =
         FileUtils.createNewFile(outputDirectory.resolve(userJourneyResultsFileName).toFile());
     File runSummaryFile = outputDirectory.resolve(runSummaryFileName).toFile();
-    File terraVersionFile = outputDirectory.resolve(terraVersionFileName).toFile();
+    File terraVersionFile = outputDirectory.resolve(envVersionFileName).toFile();
 
     // write the rendered test configuration that was run to a file
     objectWriter.writeValue(renderedConfigFile, config);

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -159,7 +159,7 @@ public class TestRunner {
     }
 
     // update any Kubernetes properties specified by the test configuration
-    if (!config.server.skipKubernetes) {
+    if (!config.server.skipKubernetes && config.disruptiveScript != null) {
       KubernetesClientUtils.buildKubernetesClientObjectWithClientKey(
           config.server, config.application);
       modifyKubernetesPostDeployment();

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -162,6 +162,7 @@ public class TestRunner {
     if (!config.server.skipKubernetes) {
       KubernetesClientUtils.buildKubernetesClientObjectWithClientKey(
           config.server, config.application);
+      KubernetesClientUtils.getComponentVersions();
       modifyKubernetesPostDeployment();
     } else {
       logger.info("Kubernetes: Skipping Kubernetes configuration post-deployment");

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -36,6 +36,9 @@ public class TestRunner {
 
   private static long secondsToWaitForPoolShutdown = 60;
 
+  private static Map<String, Map<String, String>> componentVersions =
+      new HashMap<String, Map<String, String>>();
+
   public static class TestRunSummary {
     public String id;
 
@@ -162,7 +165,7 @@ public class TestRunner {
     if (!config.server.skipKubernetes) {
       KubernetesClientUtils.buildKubernetesClientObjectWithClientKey(
           config.server, config.application);
-      KubernetesClientUtils.getComponentVersions();
+      componentVersions = KubernetesClientUtils.importComponentVersions();
       modifyKubernetesPostDeployment();
     } else {
       logger.info("Kubernetes: Skipping Kubernetes configuration post-deployment");
@@ -502,7 +505,7 @@ public class TestRunner {
     logger.info("Test run summary written to file: {}", runSummaryFile.getName());
 
     // Write the MCTerra Component versions of target environment to a file
-    objectWriter.writeValue(terraVersionFile, KubernetesClientUtils.getComponentVersions());
+    objectWriter.writeValue(terraVersionFile, componentVersions);
     logger.info("MCTerra Component versions written to file: {}", terraVersionFile.getName());
   }
 

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -159,7 +159,7 @@ public class TestRunner {
     }
 
     // update any Kubernetes properties specified by the test configuration
-    if (!config.server.skipKubernetes && config.disruptiveScript != null) {
+    if (!config.server.skipKubernetes) {
       KubernetesClientUtils.buildKubernetesClientObjectWithClientKey(
           config.server, config.application);
       modifyKubernetesPostDeployment();

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -456,6 +456,7 @@ public class TestRunner {
   private static final String renderedConfigFileName = "RENDERED_testConfiguration.json";
   private static final String userJourneyResultsFileName = "RAWDATA_userJourneyResults.json";
   private static final String runSummaryFileName = "SUMMARY_testRun.json";
+  private static final String terraVersionFileName = "TERRA_componentVersion.json";
 
   protected void writeOutResults(String outputParentDirName) throws IOException {
     // use Jackson to map the object to a JSON-formatted text block
@@ -485,6 +486,7 @@ public class TestRunner {
     File userJourneyResultsFile =
         FileUtils.createNewFile(outputDirectory.resolve(userJourneyResultsFileName).toFile());
     File runSummaryFile = outputDirectory.resolve(runSummaryFileName).toFile();
+    File terraVersionFile = outputDirectory.resolve(terraVersionFileName).toFile();
 
     // write the rendered test configuration that was run to a file
     objectWriter.writeValue(renderedConfigFile, config);
@@ -497,6 +499,10 @@ public class TestRunner {
     // write the test run summary to a file
     objectWriter.writeValue(runSummaryFile, summary);
     logger.info("Test run summary written to file: {}", runSummaryFile.getName());
+
+    // Write the MCTerra Component versions of target environment to a file
+    objectWriter.writeValue(terraVersionFile, KubernetesClientUtils.getComponentVersions());
+    logger.info("MCTerra Component versions written to file: {}", terraVersionFile.getName());
   }
 
   /**

--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -112,8 +112,7 @@ public class ServerSpecification implements SpecificationInterface {
   public void validate() {
     if (!skipKubernetes) {
       if (cluster == null) {
-        throw new IllegalArgumentException(
-                "Cluster Specification must be defined");
+        throw new IllegalArgumentException("Cluster Specification must be defined");
       }
       cluster.validate();
       if (testRunnerK8SServiceAccount == null) {
@@ -129,8 +128,7 @@ public class ServerSpecification implements SpecificationInterface {
       deploymentScript.validate();
     }
     if (testRunnerServiceAccount == null) {
-      throw new IllegalArgumentException(
-              "Test Runner Service Account must be defined");
+      throw new IllegalArgumentException("Test Runner Service Account must be defined");
     }
     testRunnerServiceAccount.validate();
 

--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -111,9 +111,6 @@ public class ServerSpecification implements SpecificationInterface {
    */
   public void validate() {
     if (!skipKubernetes) {
-      if (cluster == null) {
-        throw new IllegalArgumentException("Cluster Specification must be defined");
-      }
       cluster.validate();
       if (testRunnerK8SServiceAccount == null) {
         throw new IllegalArgumentException(
@@ -127,9 +124,7 @@ public class ServerSpecification implements SpecificationInterface {
       }
       deploymentScript.validate();
     }
-    if (testRunnerServiceAccount == null) {
-      throw new IllegalArgumentException("Test Runner Service Account must be defined");
-    }
+
     testRunnerServiceAccount.validate();
 
     if (bufferClientServiceAccount != null) {

--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -111,6 +111,10 @@ public class ServerSpecification implements SpecificationInterface {
    */
   public void validate() {
     if (!skipKubernetes) {
+      if (cluster == null) {
+        throw new IllegalArgumentException(
+                "Cluster Specification must be defined");
+      }
       cluster.validate();
       if (testRunnerK8SServiceAccount == null) {
         throw new IllegalArgumentException(
@@ -124,7 +128,10 @@ public class ServerSpecification implements SpecificationInterface {
       }
       deploymentScript.validate();
     }
-
+    if (testRunnerServiceAccount == null) {
+      throw new IllegalArgumentException(
+              "Test Runner Service Account must be defined");
+    }
     testRunnerServiceAccount.validate();
 
     if (bufferClientServiceAccount != null) {

--- a/testrunner-k8s-role.yml.template
+++ b/testrunner-k8s-role.yml.template
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/component: APP
 rules:
   - apiGroups: [""]
-    resources: [pods", "pods/exec"]
+    resources: ["pods", "pods/exec"]
     verbs: ["get", "list", "watch", "delete", "patch", "create", "update"]
   - apiGroups: [""]
     resources: ["configmaps"]

--- a/testrunner-k8s-role.yml.template
+++ b/testrunner-k8s-role.yml.template
@@ -21,8 +21,12 @@ metadata:
     app.kubernetes.io/component: APP
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/exec"]
+    resources: [pods", "pods/exec"]
     verbs: ["get", "list", "watch", "delete", "patch", "create", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["terra-component-version"]
+    verbs: ["get", "patch", "update"]
   - apiGroups: ["extensions", "apps"]
     resources: ["deployments", "deployments/scale"]
     verbs: ["get", "list", "watch", "delete", "patch", "create", "update"]


### PR DESCRIPTION
The goal of this Pull Request is for the extension of the current Test Runner Framework to import `MCTerra` Component versions from the target Kubernetes namespace.

The ground truth of the component versions for different environments are obtained from the `terra-helmfile` version manifests.

In order to support the `ConfigMap` operations the Test Runner Library needs, the RBAC role has also been updated to enable `get, patch, and update` operations pertaining to the Component Version ConfigMap.

