### PR TITLE
PF-790, PF-791, PF-779, PF-443: Move upload scripts into Test Runner library + bug fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.0.3-SNAPSHOT'
+version '0.0.4-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')

--- a/src/main/java/bio/terra/testrunner/collector/MeasurementCollectionScript.java
+++ b/src/main/java/bio/terra/testrunner/collector/MeasurementCollectionScript.java
@@ -22,7 +22,11 @@ public abstract class MeasurementCollectionScript<T> {
   protected MeasurementResultSummary summary;
 
   @SuppressFBWarnings(
-      value = {"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", "UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"},
+      value = {
+        "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+        "UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD",
+        "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
+      },
       justification = "This POJO class is used for easy serialization to JSON using Jackson.")
   public static class MeasurementResultSummary {
     public String description;
@@ -68,7 +72,8 @@ public abstract class MeasurementCollectionScript<T> {
 
   /**
    * Download the raw data points generated during this test run. Then process them to calculate
-   * reporting statistics of interest.
+   * reporting statistics of interest. Sub-classes must populate the statistics property of this
+   * class.
    */
   public void processDataPoints(long startTimeMS, long endTimeMS) throws Exception {
     throw new UnsupportedOperationException("downloadDataPoints must be overridden by sub-classes");

--- a/src/main/java/bio/terra/testrunner/common/commands/PrintHelp.java
+++ b/src/main/java/bio/terra/testrunner/common/commands/PrintHelp.java
@@ -4,6 +4,7 @@ import bio.terra.testrunner.collector.config.MeasurementList;
 import bio.terra.testrunner.common.utils.FileUtils;
 import bio.terra.testrunner.runner.config.TestConfiguration;
 import bio.terra.testrunner.runner.config.TestSuite;
+import bio.terra.testrunner.uploader.config.UploadList;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -98,6 +99,9 @@ public class PrintHelp {
             + System.lineSeparator()
             + "  outputDirectoryName = name of the same directory that contains the Test Runner and measurement results"
             + System.lineSeparator());
+    // print out the available upload lists found in the resources directory
+    System.out.println("  The following upload lists were found:");
+    printAvailableFiles(UploadList.resourceDirectory, null);
 
     // example workflows
     System.out.println(

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -523,11 +523,11 @@ public class TestRunner {
   }
 
   /** Helper method to print out the PASSED/FAILED tests at the end of a suite run. */
-  protected static void printSuiteResults(Map<String, Boolean> testConfigNameToResult) {
+  protected static void printSuiteResults(Map<String, Boolean> testConfigNameToFailed) {
     System.out.println(ANSI_PURPLE + "PASSED test configurations" + ANSI_RESET);
     List<String> passedTestConfigs =
-        testConfigNameToResult.keySet().stream()
-            .filter(testConfigName -> !testConfigNameToResult.get(testConfigName))
+        testConfigNameToFailed.keySet().stream()
+            .filter(testConfigName -> !testConfigNameToFailed.get(testConfigName))
             .collect(Collectors.toList());
     for (String passingTestConfig : passedTestConfigs) {
       System.out.println(passingTestConfig + System.lineSeparator());
@@ -536,8 +536,8 @@ public class TestRunner {
 
     System.out.println(ANSI_PURPLE + "FAILED test configurations" + ANSI_RESET);
     List<String> failedTestConfigs =
-        testConfigNameToResult.keySet().stream()
-            .filter(testConfigName -> testConfigNameToResult.get(testConfigName))
+        testConfigNameToFailed.keySet().stream()
+            .filter(testConfigName -> testConfigNameToFailed.get(testConfigName))
             .collect(Collectors.toList());
     for (String failedTestConfig : failedTestConfigs) {
       System.out.println(failedTestConfig + System.lineSeparator());
@@ -631,7 +631,7 @@ public class TestRunner {
     testSuite.validate();
 
     boolean isFailure = false;
-    Map<String, Boolean> testConfigNameToResult = new HashMap<>();
+    Map<String, Boolean> testConfigNameToFailed = new HashMap<>();
     for (int ctr = 0; ctr < testSuite.testConfigurations.size(); ctr++) {
       TestConfiguration testConfiguration = testSuite.testConfigurations.get(ctr);
 
@@ -660,7 +660,7 @@ public class TestRunner {
       }
 
       // update the failure flag for this test config and the whole suite
-      testConfigNameToResult.put(testConfiguration.name, testConfigFailed);
+      testConfigNameToFailed.put(testConfiguration.name, testConfigFailed);
       isFailure = isFailure || testConfigFailed;
 
       logger.info("==== TEST RUN RESULTS ({}) {} ====", ctr + 1, testConfiguration.name);
@@ -677,7 +677,7 @@ public class TestRunner {
 
       TimeUnit.SECONDS.sleep(5);
     }
-    printSuiteResults(testConfigNameToResult);
+    printSuiteResults(testConfigNameToFailed);
 
     return isFailure;
   }

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -1,5 +1,8 @@
 package bio.terra.testrunner.runner;
 
+import static bio.terra.testrunner.common.commands.PrintHelp.ANSI_PURPLE;
+import static bio.terra.testrunner.common.commands.PrintHelp.ANSI_RESET;
+
 import bio.terra.testrunner.common.utils.FileUtils;
 import bio.terra.testrunner.common.utils.KubernetesClientUtils;
 import bio.terra.testrunner.runner.config.TestConfiguration;
@@ -38,6 +41,8 @@ public class TestRunner {
 
   private static Map<String, Map<String, String>> componentVersions =
       new HashMap<String, Map<String, String>>();
+
+  private boolean exceptionThrownInCleanup = false;
 
   public static class TestRunSummary {
     public String id;
@@ -118,12 +123,17 @@ public class TestRunner {
       }
 
       // cleanup test scripts (i.e. run cleanup methods)
-      logger.info("Test Scripts: Calling the cleanup methods after failure");
-      try {
-        callTestScriptCleanups();
-      } catch (Exception testScriptCleanupEx) {
-        logger.error(
-            "Test Scripts: Exception during forced test script cleanups", testScriptCleanupEx);
+      if (exceptionThrownInCleanup) {
+        logger.info(
+            "Test Script: Exception thrown in cleanup methods, so not re-trying during cleanup");
+      } else {
+        logger.info("Test Scripts: Calling the cleanup methods after failure");
+        try {
+          callTestScriptCleanups();
+        } catch (Exception testScriptCleanupEx) {
+          logger.error(
+              "Test Scripts: Exception during forced test script cleanups", testScriptCleanupEx);
+        }
       }
 
       throw originalEx;
@@ -332,6 +342,7 @@ public class TestRunner {
     logger.info("Test Scripts: Calling the cleanup methods");
     Exception cleanupExceptionThrown = callTestScriptCleanups();
     if (cleanupExceptionThrown != null) {
+      exceptionThrownInCleanup = true;
       logger.error(
           "Test Scripts: Error calling test script cleanup methods", cleanupExceptionThrown);
       throw new RuntimeException(
@@ -410,6 +421,7 @@ public class TestRunner {
         testScript.userJourney(testUser);
       } catch (Exception ex) {
         result.exceptionThrown = ex;
+        ex.printStackTrace(); // print the stack trace to the console
       }
       result.elapsedTimeNS = System.nanoTime() - startTime;
 
@@ -462,6 +474,7 @@ public class TestRunner {
   private static final String runSummaryFileName = "SUMMARY_testRun.json";
   private static final String envVersionFileName = "ENV_componentVersion.json";
 
+  /** Helper method to write out the results to files at the end of a test configuration run. */
   protected void writeOutResults(String outputParentDirName) throws IOException {
     // use Jackson to map the object to a JSON-formatted text block
     ObjectMapper objectMapper = new ObjectMapper();
@@ -507,6 +520,29 @@ public class TestRunner {
     // Write the MCTerra Component versions of target environment to a file
     objectWriter.writeValue(terraVersionFile, componentVersions);
     logger.info("MCTerra Component versions written to file: {}", terraVersionFile.getName());
+  }
+
+  /** Helper method to print out the PASSED/FAILED tests at the end of a suite run. */
+  protected static void printSuiteResults(Map<String, Boolean> testConfigNameToResult) {
+    System.out.println(ANSI_PURPLE + "PASSED test configurations" + ANSI_RESET);
+    List<String> passedTestConfigs =
+        testConfigNameToResult.keySet().stream()
+            .filter(testConfigName -> !testConfigNameToResult.get(testConfigName))
+            .collect(Collectors.toList());
+    for (String passingTestConfig : passedTestConfigs) {
+      System.out.println(passingTestConfig + System.lineSeparator());
+    }
+    System.out.println(System.lineSeparator());
+
+    System.out.println(ANSI_PURPLE + "FAILED test configurations" + ANSI_RESET);
+    List<String> failedTestConfigs =
+        testConfigNameToResult.keySet().stream()
+            .filter(testConfigName -> testConfigNameToResult.get(testConfigName))
+            .collect(Collectors.toList());
+    for (String failedTestConfig : failedTestConfigs) {
+      System.out.println(failedTestConfig + System.lineSeparator());
+    }
+    System.out.println(System.lineSeparator());
   }
 
   /**
@@ -595,6 +631,7 @@ public class TestRunner {
     testSuite.validate();
 
     boolean isFailure = false;
+    Map<String, Boolean> testConfigNameToResult = new HashMap<>();
     for (int ctr = 0; ctr < testSuite.testConfigurations.size(); ctr++) {
       TestConfiguration testConfiguration = testSuite.testConfigurations.get(ctr);
 
@@ -604,23 +641,27 @@ public class TestRunner {
 
       // get an instance of a runner and tell it to execute the configuration
       TestRunner runner = new TestRunner(testConfiguration);
+      boolean testConfigFailed = false;
       try {
         runner.executeTestConfiguration();
 
-        // update the failure flag if it's not already been set
-        if (!isFailure) {
-          for (TestScriptResult.TestScriptResultSummary testScriptResultSummary :
-              runner.summary.testScriptResultSummaries) {
-            if (testScriptResultSummary.isFailure) {
-              isFailure = true;
-              break;
-            }
+        // even if the test configuration didn't throw an exception, it still may have failed due to
+        // a timeout
+        for (TestScriptResult.TestScriptResultSummary testScriptResultSummary :
+            runner.summary.testScriptResultSummaries) {
+          if (testScriptResultSummary.isFailure) {
+            testConfigFailed = true;
+            break;
           }
         }
       } catch (Exception runnerEx) {
         logger.error("Test Runner threw an exception", runnerEx);
-        isFailure = true;
+        testConfigFailed = true;
       }
+
+      // update the failure flag for this test config and the whole suite
+      testConfigNameToResult.put(testConfiguration.name, testConfigFailed);
+      isFailure = isFailure || testConfigFailed;
 
       logger.info("==== TEST RUN RESULTS ({}) {} ====", ctr + 1, testConfiguration.name);
       String outputDirName =
@@ -636,6 +677,7 @@ public class TestRunner {
 
       TimeUnit.SECONDS.sleep(5);
     }
+    printSuiteResults(testConfigNameToResult);
 
     return isFailure;
   }

--- a/src/main/java/bio/terra/testrunner/runner/TestScriptResult.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestScriptResult.java
@@ -19,6 +19,7 @@ public class TestScriptResult {
       value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
       justification = "This POJO class is used for easy serialization to JSON using Jackson.")
   public static class TestScriptResultSummary {
+    public String testScriptName;
     public String testScriptDescription;
 
     public BasicStatistics elapsedTimeStatistics;
@@ -31,7 +32,8 @@ public class TestScriptResult {
 
     public TestScriptResultSummary() {} // default constructor so Jackson can deserialize
 
-    private TestScriptResultSummary(String testScriptDescription) {
+    private TestScriptResultSummary(String testScriptName, String testScriptDescription) {
+      this.testScriptName = testScriptName;
       this.testScriptDescription = testScriptDescription;
     }
   }
@@ -40,7 +42,9 @@ public class TestScriptResult {
       TestScriptSpecification testScriptSpecification, List<UserJourneyResult> userJourneyResults) {
     this.userJourneyResults = userJourneyResults;
 
-    summary = new TestScriptResultSummary(testScriptSpecification.description);
+    summary =
+        new TestScriptResultSummary(
+            testScriptSpecification.name, testScriptSpecification.description);
     calculateStatistics();
   }
 

--- a/src/main/java/bio/terra/testrunner/uploader/ResultUploader.java
+++ b/src/main/java/bio/terra/testrunner/uploader/ResultUploader.java
@@ -28,7 +28,7 @@ public class ResultUploader {
       script.setParameters(specification.parameters);
 
       // upload the results somewhere
-      logger.info("Executing measurement collection script: {}", specification.description);
+      logger.info("Executing upload script: {}", specification.description);
       script.uploadResults(outputDirectory, uploadList.uploaderServiceAccount);
     }
   }

--- a/src/main/java/scripts/uploadscripts/CompressDirectoryToBucket.java
+++ b/src/main/java/scripts/uploadscripts/CompressDirectoryToBucket.java
@@ -1,0 +1,84 @@
+package scripts.uploadscripts;
+
+import bio.terra.testrunner.common.utils.FileUtils;
+import bio.terra.testrunner.common.utils.StorageUtils;
+import bio.terra.testrunner.runner.TestRunner;
+import bio.terra.testrunner.runner.config.ServiceAccountSpecification;
+import bio.terra.testrunner.uploader.UploadScript;
+import com.google.api.client.util.ByteStreams;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.file.Path;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CompressDirectoryToBucket extends UploadScript {
+  private static final Logger logger = LoggerFactory.getLogger(CompressDirectoryToBucket.class);
+
+  /** Public constructor so that this class can be instantiated via reflection. */
+  public CompressDirectoryToBucket() {}
+
+  protected String bucketPath;
+
+  /**
+   * Setter for any parameters required by the upload script. These parameters will be set by the
+   * Result Uploader based on the current Upload List, and can be used by the upload script methods.
+   *
+   * @param parameters list of string parameters supplied by the upload list
+   */
+  public void setParameters(List<String> parameters) throws Exception {
+    if (parameters == null || parameters.size() < 1) {
+      throw new IllegalArgumentException("Must provide bucket path in the parameters list");
+    }
+    bucketPath = parameters.get(0);
+    if (!bucketPath.startsWith("gs://")) { // only handle GCS buckets
+      throw new IllegalArgumentException("Bucket path must start with gs://");
+    }
+  }
+
+  /**
+   * Upload the test results saved to the given directory. Results may include Test Runner
+   * client-side output and any relevant measurements collected.
+   */
+  @SuppressFBWarnings(
+      value = {"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"},
+      justification =
+          "Spotbugs fails with a redundant null check exception in the nested try-with-resources. More details here: https://github.com/spotbugs/spotbugs/issues/600")
+  public void uploadResults(
+      Path outputDirectory, ServiceAccountSpecification uploaderServiceAccount) throws Exception {
+    // archive file path will be: outputDirectory parent directory + test run id + .tar.gz
+    Path outputDirectoryParent = outputDirectory.getParent();
+    if (outputDirectoryParent == null) {
+      throw new IllegalArgumentException(
+          "Parent directory of the directory to compress is null: "
+              + outputDirectory.toAbsolutePath());
+    }
+    TestRunner.TestRunSummary testRunSummary = TestRunner.getTestRunSummary(outputDirectory);
+    String archiveFileName = testRunSummary.id + ".tar.gz";
+    Path archiveFile = outputDirectoryParent.resolve(archiveFileName);
+
+    // create the archive file locally
+    FileUtils.compressDirectory(outputDirectory, archiveFile);
+    logger.info("Compressed directory written locally: {}", archiveFile.toAbsolutePath());
+
+    // upload the archive file to a bucket
+    Storage storageClient = StorageUtils.getClientForServiceAccount(uploaderServiceAccount);
+    BlobInfo blobInfo =
+        BlobInfo.newBuilder(bucketPath.replace("gs://", ""), archiveFileName)
+            .setContentType("application/gzip")
+            .build();
+    try (WriteChannel writer = storageClient.writer(blobInfo)) {
+      try (InputStream inputStream = new FileInputStream(archiveFile.toFile())) {
+        ByteStreams.copy(inputStream, Channels.newOutputStream(writer));
+      }
+    }
+    logger.info(
+        "Compressed directory written to bucket: {}/{}", blobInfo.getBucket(), blobInfo.getName());
+  }
+}

--- a/src/main/java/scripts/uploadscripts/SummariesToBigQuery.java
+++ b/src/main/java/scripts/uploadscripts/SummariesToBigQuery.java
@@ -1,0 +1,231 @@
+package scripts.uploadscripts;
+
+import bio.terra.testrunner.collector.MeasurementCollectionScript;
+import bio.terra.testrunner.collector.MeasurementCollector;
+import bio.terra.testrunner.common.utils.BigQueryUtils;
+import bio.terra.testrunner.runner.TestRunner;
+import bio.terra.testrunner.runner.TestScriptResult;
+import bio.terra.testrunner.runner.config.ServiceAccountSpecification;
+import bio.terra.testrunner.runner.config.TestConfiguration;
+import bio.terra.testrunner.runner.config.TestScriptSpecification;
+import bio.terra.testrunner.uploader.UploadScript;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.TableId;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.file.Path;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressFBWarnings(
+    value = {"NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"},
+    justification =
+        "The statistics field will be populated by sub-classes of MeasurementCollectionScript.")
+public class SummariesToBigQuery extends UploadScript {
+  private static final Logger logger = LoggerFactory.getLogger(SummariesToBigQuery.class);
+
+  /** Public constructor so that this class can be instantiated via reflection. */
+  public SummariesToBigQuery() {}
+
+  protected String projectId; // google project id
+  protected String datasetName; // big query dataset name
+
+  protected TestConfiguration renderedTestConfiguration;
+  protected TestRunner.TestRunSummary testRunSummary;
+  protected MeasurementCollectionScript.MeasurementResultSummary[] measurementCollectionSummaries;
+
+  /**
+   * Setter for any parameters required by the upload script. These parameters will be set by the
+   * Result Uploader based on the current Upload List, and can be used by the upload script methods.
+   *
+   * @param parameters list of string parameters supplied by the upload list
+   */
+  @Override
+  public void setParameters(List<String> parameters) throws Exception {
+    if (parameters == null || parameters.size() < 2) {
+      throw new IllegalArgumentException(
+          "Must provide BigQuery project_id and dataset_name in the parameters list");
+    }
+    projectId = parameters.get(0);
+    datasetName = parameters.get(1);
+  }
+
+  private static String testRunTableName = "testRun";
+  private static String testScriptResultsTableName = "testScriptResults";
+  private static String measurementCollectionTableName = "measurementCollection";
+
+  /**
+   * Upload the test results saved to the given directory. Results may include Test Runner
+   * client-side output and any relevant measurements collected.
+   */
+  @Override
+  public void uploadResults(
+      Path outputDirectory, ServiceAccountSpecification uploaderServiceAccount) throws Exception {
+    // get a BigQuery client object
+    logger.debug("BigQuery project_id:dataset_name: {}:{}", projectId, datasetName);
+    BigQuery bigQueryClient =
+        BigQueryUtils.getClientForServiceAccount(uploaderServiceAccount, projectId);
+    // read in TestConfiguration TestRunSummary, and array of
+    // MeasurementCollectionScript.MeasurementResultSummary objects
+    renderedTestConfiguration = TestRunner.getRenderedTestConfiguration(outputDirectory);
+    testRunSummary = TestRunner.getTestRunSummary(outputDirectory);
+    measurementCollectionSummaries =
+        MeasurementCollector.getMeasurementCollectionSummaries(outputDirectory);
+
+    // insert a single row into testRun
+    if (BigQueryUtils.checkRowExists(
+        bigQueryClient, projectId, datasetName, testRunTableName, "id", testRunSummary.id)) {
+      logger.warn(
+          "A row with this id already exists in the "
+              + testRunTableName
+              + " table. Inserting a duplicate.");
+    }
+    TableId tableId = TableId.of(datasetName, testRunTableName);
+    InsertAllRequest insertRequest =
+        InsertAllRequest.newBuilder(tableId).addRow(buildTestRunRow(outputDirectory)).build();
+    BigQueryUtils.insertAllIntoBigQuery(bigQueryClient, insertRequest);
+
+    // insert into testScriptResults
+    tableId = TableId.of(datasetName, testScriptResultsTableName);
+    InsertAllRequest.Builder insertRequestBuilder = InsertAllRequest.newBuilder(tableId);
+    // Store test summaries in a Map with test names as keys
+    Map<String, TestScriptResult.TestScriptResultSummary> testScriptResultSummaries =
+        new ConcurrentHashMap<String, TestScriptResult.TestScriptResultSummary>();
+    testRunSummary.testScriptResultSummaries.stream()
+        .forEach(
+            runSummary -> testScriptResultSummaries.put(runSummary.testScriptName, runSummary));
+    // Loop through all test summaries
+    for (TestScriptSpecification testScriptSpecification : renderedTestConfiguration.testScripts) {
+      if (testScriptResultSummaries.containsKey(testScriptSpecification.name)) {
+        insertRequestBuilder.addRow(
+            buildTestScriptResultsRow(
+                testScriptSpecification,
+                testScriptResultSummaries.get(testScriptSpecification.name)));
+      } else {
+        logger.debug("Test name {} not found in result summaries.", testScriptSpecification.name);
+      }
+    }
+    BigQueryUtils.insertAllIntoBigQuery(bigQueryClient, insertRequestBuilder.build());
+
+    // insert into measurementCollection
+    if (measurementCollectionSummaries == null) {
+      logger.info("No measurement summaries found.");
+    } else {
+      tableId = TableId.of(datasetName, measurementCollectionTableName);
+      insertRequestBuilder = InsertAllRequest.newBuilder(tableId);
+      for (MeasurementCollectionScript.MeasurementResultSummary measurementResult :
+          measurementCollectionSummaries) {
+        insertRequestBuilder.addRow(buildMeasurementCollectionRow(measurementResult));
+      }
+      BigQueryUtils.insertAllIntoBigQuery(bigQueryClient, insertRequestBuilder.build());
+    }
+  }
+
+  /** Build a single row for each measurement collection. */
+  private Map<String, Object> buildMeasurementCollectionRow(
+      MeasurementCollectionScript.MeasurementResultSummary measurementResult) {
+    Map<String, Object> rowContent = new HashMap<>();
+
+    rowContent.put("testRun_id", testRunSummary.id);
+
+    rowContent.put("description", measurementResult.description);
+
+    rowContent.put("statistics_min", String.valueOf(measurementResult.statistics.min));
+    rowContent.put("statistics_max", String.valueOf(measurementResult.statistics.max));
+    rowContent.put("statistics_mean", String.valueOf(measurementResult.statistics.mean));
+    rowContent.put(
+        "statistics_standardDeviation",
+        String.valueOf(measurementResult.statistics.standardDeviation));
+    rowContent.put("statistics_median", String.valueOf(measurementResult.statistics.median));
+    rowContent.put(
+        "statistics_percentile95", String.valueOf(measurementResult.statistics.percentile95));
+    rowContent.put(
+        "statistics_percentile99", String.valueOf(measurementResult.statistics.percentile99));
+    rowContent.put("statistics_sum", String.valueOf(measurementResult.statistics.sum));
+
+    return rowContent;
+  }
+
+  /** Build a single row for each test script result. */
+  private Map<String, Object> buildTestScriptResultsRow(
+      TestScriptSpecification testScriptSpecification,
+      TestScriptResult.TestScriptResultSummary testScriptResult) {
+    Map<String, Object> rowContent = new HashMap<>();
+
+    rowContent.put("testRun_id", testRunSummary.id);
+
+    rowContent.put("name", testScriptSpecification.name);
+    rowContent.put(
+        "numberOfUserJourneyThreadsToRun", testScriptSpecification.numberOfUserJourneyThreadsToRun);
+    rowContent.put("userJourneyThreadPoolSize", testScriptSpecification.userJourneyThreadPoolSize);
+    rowContent.put("expectedTimeForEach", testScriptSpecification.expectedTimeForEach);
+    rowContent.put("expectedTimeForEachUnit", testScriptSpecification.expectedTimeForEachUnit);
+    rowContent.put("parameters", testScriptSpecification.parameters);
+
+    rowContent.put("description", testScriptResult.testScriptDescription);
+    rowContent.put("elapsedTime_min", testScriptResult.elapsedTimeStatistics.min);
+    rowContent.put("elapsedTime_max", testScriptResult.elapsedTimeStatistics.max);
+    rowContent.put("elapsedTime_mean", testScriptResult.elapsedTimeStatistics.mean);
+    rowContent.put(
+        "elapsedTime_standardDeviation", testScriptResult.elapsedTimeStatistics.standardDeviation);
+    rowContent.put("elapsedTime_median", testScriptResult.elapsedTimeStatistics.median);
+    rowContent.put("elapsedTime_percentile95", testScriptResult.elapsedTimeStatistics.percentile95);
+    rowContent.put("elapsedTime_percentile99", testScriptResult.elapsedTimeStatistics.percentile99);
+    rowContent.put("elapsedTime_sum", testScriptResult.elapsedTimeStatistics.sum);
+
+    rowContent.put("totalRun", testScriptResult.totalRun);
+    rowContent.put("numCompleted", testScriptResult.numCompleted);
+    rowContent.put("numExceptionsThrown", testScriptResult.numExceptionsThrown);
+    rowContent.put("isFailure", testScriptResult.isFailure);
+
+    return rowContent;
+  }
+
+  /** Build a single row for each test run. */
+  private Map<String, Object> buildTestRunRow(Path outputDirectory) throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    Map<String, Object> rowContent = new HashMap<>();
+
+    rowContent.put("id", testRunSummary.id);
+    rowContent.put("testConfig_name", renderedTestConfiguration.name);
+    rowContent.put("testConfig_description", renderedTestConfiguration.description);
+    rowContent.put("server_name", renderedTestConfiguration.server.name);
+    rowContent.put(
+        "kubernetes_numberOfInitialPods", renderedTestConfiguration.kubernetes.numberOfInitialPods);
+    rowContent.put(
+        "testUsers", renderedTestConfiguration.testUsers.stream().map(tu -> tu.name).toArray());
+
+    TimeZone originalDefaultTimeZone = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    rowContent.put(
+        "startTime", Timestamp.from(Instant.ofEpochMilli(testRunSummary.startTime)).toString());
+    rowContent.put(
+        "startUserJourneyTime",
+        Timestamp.from(Instant.ofEpochMilli(testRunSummary.startUserJourneyTime)).toString());
+    rowContent.put(
+        "endUserJourneyTime",
+        Timestamp.from(Instant.ofEpochMilli(testRunSummary.endUserJourneyTime)).toString());
+    rowContent.put(
+        "endTime", Timestamp.from(Instant.ofEpochMilli(testRunSummary.endTime)).toString());
+    TimeZone.setDefault(originalDefaultTimeZone);
+
+    rowContent.put("outputDirectory", outputDirectory.toAbsolutePath().toString());
+    rowContent.put(
+        "json_testConfiguration", objectMapper.writeValueAsString(renderedTestConfiguration));
+    rowContent.put("json_testRun", objectMapper.writeValueAsString(testRunSummary));
+    rowContent.put(
+        "json_measurementCollection",
+        objectMapper.writeValueAsString(measurementCollectionSummaries));
+
+    return rowContent;
+  }
+}


### PR DESCRIPTION
One bug fix for upload scripts that is showing up in WSM + a few other less urgent bugs/requested changes.

- ([PF-790](https://broadworkbench.atlassian.net/browse/PF-790)) Included the test script name and description in the result summary. Previously only the description was included, and this was causing an error when uploading results to BQ. 
  - More detail: The test script description (different from the test configuration description) is generated by Test Runner as test script class name + list of parameters. The upload script was trying to lookup a test script result by name and failing when there were any parameters, because then name != description.

- Moved the two upload scripts (copy results into a GCS bucket, insert results into a BQ dataset) into the Test Runner library. These are not service-specific. In fact they're dependent on the structure of the Test Runner output, so it makes sense to keep them here instead of in the service repos. Service repos can still define their own upload scripts, in addition to these.

- ([PF-791](https://broadworkbench.atlassian.net/browse/PF-791)) Print the stack trace of any exception thrown in a user journey to the console. The exception is also saved in the user journey results written to a file in the output directory. For multi-threaded tests, this may not be so useful if >1 user journey thread throws an exception. This change is intended for debugging, which is often single-threaded.

- ([PF-443](https://broadworkbench.atlassian.net/browse/PF-443)) Don't re-run the `cleanup` methods if the failure occurred in a `cleanup` method to begin with. Most of the time, failures occur in the `userJourney`. This came up with RBS, which does an assertion in the `cleanup` method.

- ([PF-779](https://broadworkbench.atlassian.net/browse/PF-779)) Print a summary of what passed/failed at the end of a test run.

- Include the list of available upload list files in the help. (`./gradlew printHelp`) Test suites, test configurations, and measurement lists were already included.

**AFTER REVIEW**
- Publish a new Test Runner library with these changes.
- Open a [PR](https://github.com/DataBiosphere/terra-workspace-manager/pull/355) with WSM to bump the Test Runner library version and delete the upload scripts that are now provided by the Test Runner library.