### PR TITLE
PF-657: Removed the caching of service accounts for obtaining various credentials for running tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ HELP.md
 .gradle
 build/
 tools/*.y*ml
+tools/terra-helm
+tools/terra-helmfile
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**
 !**/src/test/**

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ resources/servers directory. Below are the available fields:
   * zone: Zone where the cluster is running
   * project: Google project under which the cluster is running
   * componentLabel: A Kubernetes metadata label key used to identify the service deployment
-  * apiComponentLabel: The value associated with the `componentLabel`
+  * apiComponentLabel: The value associated with the `componentLabel`, defaults to `api` if unspecified.
   * namespace: (optional) Name of the Kubernetes namespace where the Data Repo instance is deployed
   * deploymentScript: Name of the deployment script class to run. Only required if skipDeployment is false
   * skipDeployment: (optional) true to skip the deployment script, default is false

--- a/README.md
+++ b/README.md
@@ -479,7 +479,10 @@ resources/servers directory. Below are the available fields:
   * clusterName: Name of the Kubernetes cluster where the Data Repo instance is deployed
   * clusterShortName: Name of the cluster, stripped of the region and project qualifiers
   * region: Region where the cluster is running
+  * zone: Zone where the cluster is running
   * project: Google project under which the cluster is running
+  * componentLabel: A Kubernetes metadata label key used to identify the service deployment
+  * apiComponentLabel: The value associated with the `componentLabel`
   * namespace: (optional) Name of the Kubernetes namespace where the Data Repo instance is deployed
   * deploymentScript: Name of the deployment script class to run. Only required if skipDeployment is false
   * skipDeployment: (optional) true to skip the deployment script, default is false

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.0.4-SNAPSHOT'
+version '0.0.5-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')

--- a/src/main/java/bio/terra/testrunner/common/utils/AuthenticationUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/AuthenticationUtils.java
@@ -39,9 +39,7 @@ public final class AuthenticationUtils {
       TestUserSpecification testUser, List<String> scopes) throws IOException {
     GoogleCredentials serviceAccountCredential =
         getServiceAccountCredential(testUser.delegatorServiceAccount, cloudPlatformScope);
-    GoogleCredentials delegatedUserCredential =
-        serviceAccountCredential.createScoped(scopes).createDelegated(testUser.userEmail);
-    return delegatedUserCredential;
+    return serviceAccountCredential.createScoped(scopes).createDelegated(testUser.userEmail);
   }
 
   /**
@@ -62,9 +60,7 @@ public final class AuthenticationUtils {
   public static GoogleCredentials getServiceAccountCredential(
       ServiceAccountSpecification serviceAccount, List<String> scopes) throws IOException {
     File jsonKey = serviceAccount.jsonKeyFile;
-    GoogleCredentials serviceAccountCredential =
-        ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey)).createScoped(scopes);
-    return serviceAccountCredential;
+    return ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey)).createScoped(scopes);
   }
 
   /**
@@ -75,9 +71,7 @@ public final class AuthenticationUtils {
    */
   public static GoogleCredentials getApplicationDefaultCredential(List<String> scopes)
       throws IOException {
-    GoogleCredentials applicationDefaultCredential =
-        GoogleCredentials.getApplicationDefault().createScoped(scopes);
-    return applicationDefaultCredential;
+    return GoogleCredentials.getApplicationDefault().createScoped(scopes);
   }
 
   /**

--- a/src/main/java/bio/terra/testrunner/common/utils/AuthenticationUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/AuthenticationUtils.java
@@ -9,15 +9,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 public final class AuthenticationUtils {
-  private static volatile GoogleCredentials applicationDefaultCredential;
-  private static Map<String, GoogleCredentials> delegatedUserCredentials =
-      new ConcurrentHashMap<>();
-
-  private static final Object lockApplicationDefaultCredential = new Object();
-  private static final Object lockServiceAccountCredential = new Object();
 
   private AuthenticationUtils() {}
 
@@ -44,16 +37,10 @@ public final class AuthenticationUtils {
    */
   public static GoogleCredentials getDelegatedUserCredential(
       TestUserSpecification testUser, List<String> scopes) throws IOException {
-    GoogleCredentials delegatedUserCredential = delegatedUserCredentials.get(testUser.userEmail);
-    if (delegatedUserCredential != null) {
-      return delegatedUserCredential;
-    }
-
     GoogleCredentials serviceAccountCredential =
         getServiceAccountCredential(testUser.delegatorServiceAccount, cloudPlatformScope);
-    delegatedUserCredential =
+    GoogleCredentials delegatedUserCredential =
         serviceAccountCredential.createScoped(scopes).createDelegated(testUser.userEmail);
-    delegatedUserCredentials.put(testUser.userEmail, delegatedUserCredential);
     return delegatedUserCredential;
   }
 
@@ -88,13 +75,8 @@ public final class AuthenticationUtils {
    */
   public static GoogleCredentials getApplicationDefaultCredential(List<String> scopes)
       throws IOException {
-    if (applicationDefaultCredential != null) {
-      return applicationDefaultCredential;
-    }
-
-    synchronized (lockApplicationDefaultCredential) {
-      applicationDefaultCredential = GoogleCredentials.getApplicationDefault().createScoped(scopes);
-    }
+    GoogleCredentials applicationDefaultCredential =
+        GoogleCredentials.getApplicationDefault().createScoped(scopes);
     return applicationDefaultCredential;
   }
 

--- a/src/main/java/bio/terra/testrunner/common/utils/AuthenticationUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/AuthenticationUtils.java
@@ -13,7 +13,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public final class AuthenticationUtils {
   private static volatile GoogleCredentials applicationDefaultCredential;
-  private static volatile GoogleCredentials serviceAccountCredential;
   private static Map<String, GoogleCredentials> delegatedUserCredentials =
       new ConcurrentHashMap<>();
 
@@ -75,15 +74,9 @@ public final class AuthenticationUtils {
    */
   public static GoogleCredentials getServiceAccountCredential(
       ServiceAccountSpecification serviceAccount, List<String> scopes) throws IOException {
-    if (serviceAccountCredential != null) {
-      return serviceAccountCredential;
-    }
-
-    synchronized (lockServiceAccountCredential) {
-      File jsonKey = serviceAccount.jsonKeyFile;
-      serviceAccountCredential =
-          ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey)).createScoped(scopes);
-    }
+    File jsonKey = serviceAccount.jsonKeyFile;
+    GoogleCredentials serviceAccountCredential =
+        ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey)).createScoped(scopes);
     return serviceAccountCredential;
   }
 

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -582,14 +582,7 @@ public final class KubernetesClientUtils {
       int podCount, String componentLabel, String apiComponentLabel) throws Exception {
     V1Deployment apiDeployment = getApiDeployment(componentLabel, apiComponentLabel);
     if (apiDeployment == null) {
-      // If the test configuration does not provide the component label,
-      // this will default to the 'api' value.
-      //
-      // If either the provided component label or default 'api' label
-      // does not exist in the k8s deployment metadata, then issue a
-      // warning and simply exit without doing anything.
-      logger.warn("Application component label '{}' was not found", apiComponentLabel);
-      return;
+      throw new RuntimeException("API deployment not found.");
     }
 
     long apiPodCount = getApiPodCount(apiDeployment, componentLabel);

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -586,6 +586,22 @@ public final class KubernetesClientUtils {
     }
 
     long apiPodCount = getApiPodCount(apiDeployment, componentLabel);
+    if (podCount == apiPodCount) {
+      logger.info(
+          "Kubernetes: The number of pods ({}) in the {}: {} deployment has already met the requirements. No scaling operation is necessary.",
+          podCount,
+          componentLabel,
+          apiComponentLabel);
+      logger.debug("Current Pod Count: {}", apiPodCount);
+      printApiPods(apiDeployment);
+      return;
+    } else {
+      logger.info(
+          "Kubernetes: Setting the initial number of pods in the {}: {} deployment replica set to {}",
+          componentLabel,
+          apiComponentLabel,
+          podCount);
+    }
     logger.debug("Pod Count: {}; Message: Before scaling pod count", apiPodCount);
     apiDeployment = changeReplicaSetSize(apiDeployment, podCount);
     waitForReplicaSetSizeChange(apiDeployment, podCount);

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -582,7 +582,14 @@ public final class KubernetesClientUtils {
       int podCount, String componentLabel, String apiComponentLabel) throws Exception {
     V1Deployment apiDeployment = getApiDeployment(componentLabel, apiComponentLabel);
     if (apiDeployment == null) {
-      throw new RuntimeException("API deployment not found.");
+      // If the test configuration does not provide the component label,
+      // this will default to the 'api' value.
+      //
+      // If either the provided component label or default 'api' label
+      // does not exist in the k8s deployment metadata, then issue a
+      // warning and simply exit without doing anything.
+      logger.warn("Application component label '{}' was not found", apiComponentLabel);
+      return;
     }
 
     long apiPodCount = getApiPodCount(apiDeployment, componentLabel);

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -195,11 +195,11 @@ public final class KubernetesClientUtils {
    *
    * @param server the server specification that points to the relevant Kubernetes cluster
    */
-  public static void buildKubernetesClientObjectWithClientKey(
-      ServerSpecification server, ApplicationSpecification application) throws Exception {
+  public static void buildKubernetesClientObjectWithClientKey(ServerSpecification server)
+      throws Exception {
     namespace = server.cluster.namespace;
-    componentLabel = application.componentLabel;
-    apiComponentLabel = application.apiComponentLabel;
+    componentLabel = server.cluster.componentLabel;
+    apiComponentLabel = server.cluster.apiComponentLabel;
     // get a refreshed SA access token and its expiration time
     logger.debug("Getting a refreshed service account access token and its expiration time");
     GoogleCredentials testRunnerServiceAccountCredentials =

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -1,6 +1,5 @@
 package bio.terra.testrunner.common.utils;
 
-import bio.terra.testrunner.runner.config.ApplicationSpecification;
 import bio.terra.testrunner.runner.config.ServerSpecification;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
@@ -85,8 +84,7 @@ public final class KubernetesClientUtils {
    * beginning of a test run, and then all subsequent fetches should use the getter methods instead.
    *
    * @param server the server specification that points to the relevant Kubernetes cluster
-   * @deprecated use {@link #buildKubernetesClientObjectWithClientKey(ServerSpecification,
-   *     ApplicationSpecification)} instead.
+   * @deprecated use {@link #buildKubernetesClientObjectWithClientKey(ServerSpecification)} instead.
    */
   @Deprecated
   public static void buildKubernetesClientObject(ServerSpecification server) throws Exception {
@@ -510,13 +508,17 @@ public final class KubernetesClientUtils {
     // https://github.com/kubernetes-client/java/issues/252
     // the following few lines were suggested as a workaround
     // https://github.com/kubernetes-client/java/issues/86
+    logger.debug("Building request to delete pod {}", podNameToDelete);
     Call call =
         getKubernetesClientCoreObject()
             .deleteNamespacedPodCall(
                 podNameToDelete, namespace, null, null, null, null, null, null, null);
+    logger.debug("Call delete pod API");
     Response response = call.execute();
+    logger.debug("Response code: {}", response.code());
     Configuration.getDefaultApiClient()
         .handleResponse(response, (new TypeToken<V1Pod>() {}).getType());
+    logger.debug("Delete {} completed", podNameToDelete);
   }
 
   /**

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -449,9 +449,13 @@ public class TestRunner {
   }
 
   private void modifyKubernetesPostDeployment() throws Exception {
-    logger.info(
-        "Kubernetes: Setting the initial number of pods in the API deployment replica set to {}",
-        config.kubernetes.numberOfInitialPods);
+    if (config.kubernetes.numberOfInitialPods == null) {
+      logger.info(
+          "Kubernetes: Keeping the number of pods in the {}: {} deployment unchanged",
+          config.server.cluster.application.componentLabel,
+          config.server.cluster.application.apiComponentLabel);
+      return;
+    }
     // The default values of component label key-value pair for locating a Terra application are
     // defined in ApplicationSpecification.
     //

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -162,7 +162,7 @@ public class TestRunner {
 
       // call the deploy and waitForDeployToFinish methods to do the deployment
       logger.info("Deployment: Calling {}.deploy()", deploymentScript.getClass().getName());
-      deploymentScript.deploy(config.server, config.application);
+      deploymentScript.deploy(config.server, config.server.cluster.application);
 
       logger.info(
           "Deployment: Calling {}.waitForDeployToFinish()", deploymentScript.getClass().getName());
@@ -174,7 +174,7 @@ public class TestRunner {
     // update any Kubernetes properties specified by the test configuration
     if (!config.server.skipKubernetes) {
       KubernetesClientUtils.buildKubernetesClientObjectWithClientKey(
-          config.server, config.application);
+          config.server, config.server.cluster.application);
       componentVersions = KubernetesClientUtils.importComponentVersions();
       modifyKubernetesPostDeployment();
     } else {
@@ -465,8 +465,8 @@ public class TestRunner {
     //
     KubernetesClientUtils.changeReplicaSetSizeAndWait(
         config.kubernetes.numberOfInitialPods,
-        config.application.componentLabel,
-        config.application.apiComponentLabel);
+        config.server.cluster.application.componentLabel,
+        config.server.cluster.application.apiComponentLabel);
   }
 
   private static final String renderedConfigFileName = "RENDERED_testConfiguration.json";

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -162,7 +162,7 @@ public class TestRunner {
 
       // call the deploy and waitForDeployToFinish methods to do the deployment
       logger.info("Deployment: Calling {}.deploy()", deploymentScript.getClass().getName());
-      deploymentScript.deploy(config.server, config.server.cluster.application);
+      deploymentScript.deploy(config.server, config.application);
 
       logger.info(
           "Deployment: Calling {}.waitForDeployToFinish()", deploymentScript.getClass().getName());
@@ -173,8 +173,7 @@ public class TestRunner {
 
     // update any Kubernetes properties specified by the test configuration
     if (!config.server.skipKubernetes) {
-      KubernetesClientUtils.buildKubernetesClientObjectWithClientKey(
-          config.server, config.server.cluster.application);
+      KubernetesClientUtils.buildKubernetesClientObjectWithClientKey(config.server);
       componentVersions = KubernetesClientUtils.importComponentVersions();
       modifyKubernetesPostDeployment();
     } else {
@@ -452,8 +451,8 @@ public class TestRunner {
     if (config.kubernetes.numberOfInitialPods == null) {
       logger.info(
           "Kubernetes: Keeping the number of pods in the {}: {} deployment unchanged",
-          config.server.cluster.application.componentLabel,
-          config.server.cluster.application.apiComponentLabel);
+          config.server.cluster.componentLabel,
+          config.server.cluster.apiComponentLabel);
       return;
     }
     // The default values of component label key-value pair for locating a Terra application are
@@ -469,8 +468,8 @@ public class TestRunner {
     //
     KubernetesClientUtils.changeReplicaSetSizeAndWait(
         config.kubernetes.numberOfInitialPods,
-        config.server.cluster.application.componentLabel,
-        config.server.cluster.application.apiComponentLabel);
+        config.server.cluster.componentLabel,
+        config.server.cluster.apiComponentLabel);
   }
 
   private static final String renderedConfigFileName = "RENDERED_testConfiguration.json";

--- a/src/main/java/bio/terra/testrunner/runner/config/ApplicationSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ApplicationSpecification.java
@@ -9,8 +9,6 @@ public class ApplicationSpecification implements SpecificationInterface {
   public int loadDriverWaitSeconds = 1;
   public long loadHistoryCopyChunkSize = 1000;
   public long loadHistoryWaitSeconds = 2;
-  public String componentLabel = "app.kubernetes.io/component";
-  public String apiComponentLabel = "api";
 
   ApplicationSpecification() {}
 

--- a/src/main/java/bio/terra/testrunner/runner/config/ClusterSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ClusterSpecification.java
@@ -13,6 +13,7 @@ public class ClusterSpecification implements SpecificationInterface {
   public String project;
   public String namespace;
   public String containerName;
+  public ApplicationSpecification application;
 
   ClusterSpecification() {}
 
@@ -33,6 +34,8 @@ public class ClusterSpecification implements SpecificationInterface {
       throw new IllegalArgumentException("Server cluster container name cannot be empty");
     } else if (zone == null || zone.equals("")) {
       throw new IllegalArgumentException("Server cluster zone cannot be empty");
+    } else if (application == null) {
+      throw new IllegalArgumentException("Server cluster application must be specified");
     }
   }
 }

--- a/src/main/java/bio/terra/testrunner/runner/config/ClusterSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ClusterSpecification.java
@@ -13,7 +13,9 @@ public class ClusterSpecification implements SpecificationInterface {
   public String project;
   public String namespace;
   public String containerName;
-  public ApplicationSpecification application;
+  // Default metadata labels to look up service deployment in k8s.
+  public String componentLabel = "app.kubernetes.io/component";
+  public String apiComponentLabel = "api";
 
   ClusterSpecification() {}
 
@@ -34,8 +36,6 @@ public class ClusterSpecification implements SpecificationInterface {
       throw new IllegalArgumentException("Server cluster container name cannot be empty");
     } else if (zone == null || zone.equals("")) {
       throw new IllegalArgumentException("Server cluster zone cannot be empty");
-    } else if (application == null) {
-      throw new IllegalArgumentException("Server cluster application must be specified");
     }
   }
 }

--- a/src/main/java/bio/terra/testrunner/runner/config/KubernetesSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/KubernetesSpecification.java
@@ -3,7 +3,7 @@ package bio.terra.testrunner.runner.config;
 import org.graalvm.compiler.core.common.SuppressFBWarnings;
 
 public class KubernetesSpecification implements SpecificationInterface {
-  @SuppressFBWarnings(value = "UWF_NULL_FIELD", justification = "")
+  @SuppressFBWarnings(value = "UWF_NULL_FIELD", justification = "Forcing numberOfInitialPods to accept null as a valid scenario")
   public Integer numberOfInitialPods = null;
 
   KubernetesSpecification() {}

--- a/src/main/java/bio/terra/testrunner/runner/config/KubernetesSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/KubernetesSpecification.java
@@ -1,13 +1,16 @@
 package bio.terra.testrunner.runner.config;
 
+import org.graalvm.compiler.core.common.SuppressFBWarnings;
+
 public class KubernetesSpecification implements SpecificationInterface {
-  public int numberOfInitialPods = 1;
+  @SuppressFBWarnings(value = "UWF_NULL_FIELD", justification = "")
+  public Integer numberOfInitialPods = null;
 
   KubernetesSpecification() {}
 
   /** Validate the Kubernetes specification read in from the JSON file. */
   public void validate() {
-    if (numberOfInitialPods <= 0) {
+    if (numberOfInitialPods != null && numberOfInitialPods <= 0) {
       throw new IllegalArgumentException("Number of initial Kubernetes pods must be >= 0");
     }
   }

--- a/src/main/java/bio/terra/testrunner/runner/config/KubernetesSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/KubernetesSpecification.java
@@ -3,7 +3,7 @@ package bio.terra.testrunner.runner.config;
 import org.graalvm.compiler.core.common.SuppressFBWarnings;
 
 public class KubernetesSpecification implements SpecificationInterface {
-  @SuppressFBWarnings(value = "UWF_NULL_FIELD", justification = "Forcing numberOfInitialPods to accept null as a valid scenario")
+  @SuppressFBWarnings(value = "UWF_NULL_FIELD", justification = "must be >=0 or unspecified.")
   public Integer numberOfInitialPods = null;
 
   KubernetesSpecification() {}

--- a/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
@@ -59,7 +59,7 @@ public class TestConfiguration implements SpecificationInterface {
       testConfig.testUsers.add(testUser);
     }
 
-    // instantiate default kubernetes, if null
+    // instantiate default kubernetes, application specification objects, if null
     if (testConfig.kubernetes == null) {
       logger.debug("Test Configuration: Using default Kubernetes specification");
       testConfig.kubernetes = new KubernetesSpecification();

--- a/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
@@ -86,7 +86,7 @@ public class TestConfiguration implements SpecificationInterface {
    * of the objects, for example by parsing the string values in the JSON object.
    */
   public void validate() {
-    logger.debug("Validating the server, Kubernetes specification");
+    logger.debug("Validating the server, Kubernetes and application specifications");
     server.validate();
     kubernetes.validate();
     application.validate();

--- a/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
@@ -20,7 +20,6 @@ public class TestConfiguration implements SpecificationInterface {
 
   public ServerSpecification server;
   public KubernetesSpecification kubernetes;
-  public ApplicationSpecification application;
   public List<TestScriptSpecification> testScripts;
   public List<TestUserSpecification> testUsers = new ArrayList<>();
   public DisruptiveScriptSpecification disruptiveScript;
@@ -59,14 +58,10 @@ public class TestConfiguration implements SpecificationInterface {
       testConfig.testUsers.add(testUser);
     }
 
-    // instantiate default kubernetes, application specification objects, if null
+    // instantiate default kubernetes, if null
     if (testConfig.kubernetes == null) {
       logger.debug("Test Configuration: Using default Kubernetes specification");
       testConfig.kubernetes = new KubernetesSpecification();
-    }
-    if (testConfig.application == null) {
-      logger.debug("Test Configuration: Using default application specification");
-      testConfig.application = new ApplicationSpecification();
     }
 
     return testConfig;
@@ -86,10 +81,9 @@ public class TestConfiguration implements SpecificationInterface {
    * of the objects, for example by parsing the string values in the JSON object.
    */
   public void validate() {
-    logger.debug("Validating the server, Kubernetes and application specifications");
+    logger.debug("Validating the server, Kubernetes specification");
     server.validate();
     kubernetes.validate();
-    application.validate();
     if (disruptiveScript != null) {
       disruptiveScript.validate();
 

--- a/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
@@ -20,6 +20,7 @@ public class TestConfiguration implements SpecificationInterface {
 
   public ServerSpecification server;
   public KubernetesSpecification kubernetes;
+  public ApplicationSpecification application;
   public List<TestScriptSpecification> testScripts;
   public List<TestUserSpecification> testUsers = new ArrayList<>();
   public DisruptiveScriptSpecification disruptiveScript;
@@ -63,6 +64,10 @@ public class TestConfiguration implements SpecificationInterface {
       logger.debug("Test Configuration: Using default Kubernetes specification");
       testConfig.kubernetes = new KubernetesSpecification();
     }
+    if (testConfig.application == null) {
+      logger.debug("Test Configuration: Using default application specification");
+      testConfig.application = new ApplicationSpecification();
+    }
 
     return testConfig;
   }
@@ -84,6 +89,7 @@ public class TestConfiguration implements SpecificationInterface {
     logger.debug("Validating the server, Kubernetes specification");
     server.validate();
     kubernetes.validate();
+    application.validate();
     if (disruptiveScript != null) {
       disruptiveScript.validate();
 


### PR DESCRIPTION
This PR serves the following purpose.

Avoids caching the service accounts for obtaining test runner, user delegated access tokens (see [PF-657](https://broadworkbench.atlassian.net/browse/PF-657)).

Skip modification of Kubernetes if the application component label used to identify a Kubernetes deployment does not exist.

Updated `.gitignore` to ignore local helm files.

Refactored application specification so that the `componentLabel` and `apiComponetLabel` properties are now part of Cluster Specification. These properties can now be configured at the Server Specification and applied to all test configs. These labels are Terraformed and rarely change so it makes sense to move them into Server Spec rather than replicating them in every test config.

Bump version to `0.0.5-SNAPSHOT`.

