### PR TITLE
QA-1504: Enhanced logic of getApiReadyPods to fix NPE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.0.5-SNAPSHOT'
+version '0.0.6-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -658,7 +658,6 @@ public final class KubernetesClientUtils {
                         && deploymentComponentLabel.equals(
                             pod.getMetadata().getLabels().get(componentLabel))
                         && pod.getStatus().getContainerStatuses() != null
-                        && !pod.getStatus().getContainerStatuses().isEmpty()
                         && pod.getStatus().getContainerStatuses().stream()
                             .allMatch(status -> status.getReady()))
             .count();

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -641,15 +641,29 @@ public final class KubernetesClientUtils {
 
   private static long getApiReadyPods(V1Deployment deployment) throws ApiException {
     String deploymentComponentLabel = deployment.getMetadata().getLabels().get(componentLabel);
-    long apiPodCount =
+    int transientPodCounts = listPods().size();
+    logger.debug(String.format("%s: Found %s pods", deploymentComponentLabel, transientPodCounts));
+    // Enhanced the logic of pod readiness by checking readiness of ALL service containers within
+    // the pod. Checking only a partial set of containers for readiness might convey a false sense
+    // of pod readiness when in reality certain containers could take longer time to restart and
+    // become ready compared to others.
+    long readyPodCounts =
         listPods().stream()
             .filter(
                 pod ->
-                    deploymentComponentLabel.equals(
+                    pod.getMetadata().getLabels().containsKey(componentLabel)
+                        && deploymentComponentLabel.equals(
                             pod.getMetadata().getLabels().get(componentLabel))
-                        && pod.getStatus().getContainerStatuses().get(0).getReady())
+                        && pod.getStatus().getContainerStatuses() != null
+                        && !pod.getStatus().getContainerStatuses().isEmpty()
+                        && pod.getStatus().getContainerStatuses().stream()
+                            .allMatch(status -> status.getReady()))
             .count();
-    return apiPodCount;
+    logger.debug(
+        String.format(
+            "%s: %s/%s pod in ready state",
+            deploymentComponentLabel, readyPodCounts, transientPodCounts));
+    return readyPodCounts;
   }
 
   public static void printApiPods(V1Deployment deployment) throws ApiException {

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -642,7 +642,10 @@ public final class KubernetesClientUtils {
   private static long getApiReadyPods(V1Deployment deployment) throws ApiException {
     String deploymentComponentLabel = deployment.getMetadata().getLabels().get(componentLabel);
     int transientPodCounts = listPods().size();
-    logger.debug(String.format("%s: Found %s pods", deploymentComponentLabel, transientPodCounts));
+    logger.debug(
+        String.format(
+            "%s: Found %s pod%s.",
+            deploymentComponentLabel, transientPodCounts, transientPodCounts > 1 ? "s" : ""));
     // Enhanced the logic of pod readiness by checking readiness of ALL service containers within
     // the pod. Checking only a partial set of containers for readiness might convey a false sense
     // of pod readiness when in reality certain containers could take longer time to restart and
@@ -661,7 +664,7 @@ public final class KubernetesClientUtils {
             .count();
     logger.debug(
         String.format(
-            "%s: %s/%s pod in ready state",
+            "%s: %s/%s pod in ready state.",
             deploymentComponentLabel, readyPodCounts, transientPodCounts));
     return readyPodCounts;
   }


### PR DESCRIPTION
This PR is to tighten up the definition of pod readiness by ensuring ALL containers within a pod are ready.
The fix addresses occasional NPE while waiting for pod to recover during resiliency tests.