### PR TITLE
PF-861: Serialize exception stack trace as string, instead of full object.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.0.6-SNAPSHOT'
+version '0.0.7a-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.0.7a-SNAPSHOT'
+version '0.0.7-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -200,7 +200,7 @@ public class TestRunner {
 
     // call the setup method of each test script
     logger.info("Test Scripts: Calling the setup methods");
-    Exception setupExceptionThrown = callTestScriptSetups();
+    Throwable setupExceptionThrown = callTestScriptSetups();
     if (setupExceptionThrown != null) {
       logger.error("Test Scripts: Error calling test script setup methods", setupExceptionThrown);
       throw new RuntimeException("Error calling test script setup methods.", setupExceptionThrown);
@@ -321,7 +321,7 @@ public class TestRunner {
             // user journey thread threw an exception and didn't populate its own return object
             result = new UserJourneyResult(testScriptSpecification.name, "");
             result.completed = false;
-            result.exceptionThrown = execEx;
+            result.saveExceptionThrown(execEx);
           }
         else {
           // user journey either was never started or got cancelled before it finished
@@ -339,7 +339,7 @@ public class TestRunner {
 
     // call the cleanup method of each test script
     logger.info("Test Scripts: Calling the cleanup methods");
-    Exception cleanupExceptionThrown = callTestScriptCleanups();
+    Throwable cleanupExceptionThrown = callTestScriptCleanups();
     if (cleanupExceptionThrown != null) {
       exceptionThrownInCleanup = true;
       logger.error(
@@ -364,11 +364,11 @@ public class TestRunner {
    *
    * @return the exception thrown, null if none
    */
-  private Exception callTestScriptSetups() {
+  private Throwable callTestScriptSetups() {
     for (TestScript testScript : scripts) {
       try {
         testScript.setup(config.testUsers);
-      } catch (Exception setupEx) {
+      } catch (Throwable setupEx) {
         // return the first exception thrown and stop looping through the setup methods
         return setupEx;
       }
@@ -383,12 +383,12 @@ public class TestRunner {
    *
    * @return the first exception thrown, null if none
    */
-  private Exception callTestScriptCleanups() {
-    Exception exceptionThrown = null;
+  private Throwable callTestScriptCleanups() {
+    Throwable exceptionThrown = null;
     for (TestScript testScript : scripts) {
       try {
         testScript.cleanup(config.testUsers);
-      } catch (Exception cleanupEx) {
+      } catch (Throwable cleanupEx) {
         // save the first exception thrown, keep looping through the remaining cleanup methods
         // before returning
         if (exceptionThrown == null) {
@@ -418,9 +418,8 @@ public class TestRunner {
       long startTime = System.nanoTime();
       try {
         testScript.userJourney(testUser);
-      } catch (Exception ex) {
-        result.exceptionThrown = ex;
-        ex.printStackTrace(); // print the stack trace to the console
+      } catch (Throwable ex) {
+        result.saveExceptionThrown(ex);
       }
       result.elapsedTimeNS = System.nanoTime() - startTime;
 

--- a/src/main/java/bio/terra/testrunner/runner/TestScriptResult.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestScriptResult.java
@@ -60,7 +60,7 @@ public class TestScriptResult {
 
       // count the number of user journeys that completed and threw exceptions
       summary.numCompleted += (result.completed) ? 1 : 0;
-      summary.numExceptionsThrown += (result.exceptionThrown != null) ? 1 : 0;
+      summary.numExceptionsThrown += result.exceptionWasThrown ? 1 : 0;
 
       // convert elapsed time from nanosecods to milliseconds
       descriptiveStatistics.addValue(result.elapsedTimeNS / (1e6));

--- a/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
+++ b/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
@@ -29,7 +29,11 @@ public class UserJourneyResult {
     this.completed = false;
   }
 
-  /** Store the exception message and stack trace for the test results. */
+  /**
+   * Store the exception message and stack trace for the test results. Don't store the full {@link
+   * Throwable} object, because that may not always be serializable. This class is serialized to
+   * disk as part of writing out the test results, so it needs to be a POJO.
+   */
   public void saveExceptionThrown(Throwable exceptionThrown) {
     exceptionWasThrown = true;
     exceptionMessage = exceptionThrown.getMessage();

--- a/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
+++ b/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
@@ -1,6 +1,8 @@
 package bio.terra.testrunner.runner;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 @SuppressFBWarnings(
     value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
@@ -12,13 +14,30 @@ public class UserJourneyResult {
 
   public boolean completed;
   public long elapsedTimeNS;
-  public Exception exceptionThrown;
+
+  public boolean exceptionWasThrown;
+  public String exceptionStackTrace;
+  public String exceptionMessage;
 
   public UserJourneyResult(String userJourneyDescription, String threadName) {
     this.userJourneyDescription = userJourneyDescription;
     this.threadName = threadName;
 
-    this.exceptionThrown = null;
+    this.exceptionWasThrown = false;
+    this.exceptionStackTrace = null;
+    this.exceptionMessage = null;
     this.completed = false;
+  }
+
+  /** Store the exception message and stack trace for the test results. */
+  public void saveExceptionThrown(Throwable exceptionThrown) {
+    exceptionWasThrown = true;
+    exceptionMessage = exceptionThrown.getMessage();
+
+    StringWriter stackTraceStr = new StringWriter();
+    exceptionThrown.printStackTrace(new PrintWriter(stackTraceStr));
+    exceptionStackTrace = stackTraceStr.toString();
+
+    exceptionThrown.printStackTrace(); // print the stack trace to the console
   }
 }


### PR DESCRIPTION
- Previously Test Runner was serializing any exceptions thrown by a user journey threads. Test Runner doesn't need to be serializing the exception object. It just needs to preserve the stack trace and message for debugging test failures. This PR changes Test Runner to no longer serialize the full exception object, just the stack trace and message.
- Fixed a bug where Test Runner was not handling `Error`s, only `Exception`s.

**TODO**: Change the version to `0.0.7` and publish before merging this. It's already published as `0.0.7a` for testing in other repos.