### PR TITLE
QA-1554: Update TestRunner with new policyManagerUri property in ServerSpecification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.0.7-SNAPSHOT'
+version '0.0.8-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')

--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -40,6 +40,9 @@ public class ServerSpecification implements SpecificationInterface {
   // Workspace Manager-related fields
   public String workspaceManagerUri;
 
+  // Policy Service-related fields
+  public String policyManagerUri;
+
   // =============================================
   // Cluster & deployment: information required to manipulate Kubernetes and deploy
   // Kubernetes cluster specification

--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -41,6 +41,7 @@ public class ServerSpecification implements SpecificationInterface {
   public String workspaceManagerUri;
 
   // Policy Service-related fields
+  // Formally, Terraform used the externalcreds module to identify this service.
   public String policyManagerUri;
 
   // =============================================

--- a/tools/component-version-configmap.yml.template
+++ b/tools/component-version-configmap.yml.template
@@ -34,6 +34,9 @@ data:
   elasticsearch.properties: |
     appVersion=_TERRA_elasticsearch_appVersion_
     chartVersion=_TERRA_elasticsearch_chartVersion_
+  externalcreds.properties: |
+    appVersion=_TERRA_externalcreds_appVersion_
+    chartVersion=_TERRA_externalcreds_chartVersion_
   firecloudorch.properties: |
     appVersion=_TERRA_firecloudorch_appVersion_
     chartVersion=_TERRA_firecloudorch_chartVersion_


### PR DESCRIPTION
This is a minor update to support `Policy Team's` new service endpoint `policyManagerUri`. The Jira ticket is [QA-1554](https://broadworkbench.atlassian.net/browse/QA-1554).

Added `policyManagerUri` to `ServerSpecification`. 

The uri properties are already optional, validation does not check for null or empty values so we should be fine.

