### PR TITLE
QA-1607: Enhance TestRunner to include test types based on the test suite configuration.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.0.8-SNAPSHOT'
+version '0.0.9-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -63,10 +63,13 @@ public class TestRunner {
     private String startUserJourneyTimestamp;
     private String endUserJourneyTimestamp;
     private String endTimestamp;
-    // Include the resourceFileName of test config in the summary:
+    // Include the user-provided resourceFileName of test config in the summary:
     //  perf/**.json, integration/**.json, resiliency/**.json
-    // This facilitates grouping of test runner results on the dashboard.
+    // This can be used to facilitate grouping of test runner results on the dashboard.
     private String resourceFileName;
+    // Include user-provided TestSuite name in the summary:
+    // This can be used to facilitate grouping of test runner results on the dashboard.
+    private String testSuiteName;
 
     public String getStartTimestamp() {
       return millisecondsToTimestampString(startTime);
@@ -90,6 +93,14 @@ public class TestRunner {
 
     public void setResourceFileName(String resourceFileName) {
       this.resourceFileName = resourceFileName;
+    }
+
+    public String getTestSuiteName() {
+      return testSuiteName;
+    }
+
+    public void setTestSuiteName(String testSuiteName) {
+      this.testSuiteName = testSuiteName;
     }
 
     private static String millisecondsToTimestampString(long milliseconds) {
@@ -656,6 +667,7 @@ public class TestRunner {
 
       // get an instance of a runner and tell it to execute the configuration
       TestRunner runner = new TestRunner(testConfiguration);
+      runner.summary.setTestSuiteName(testSuite.name);
       boolean testConfigFailed = false;
       try {
         runner.executeTestConfiguration();

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -63,6 +63,10 @@ public class TestRunner {
     private String startUserJourneyTimestamp;
     private String endUserJourneyTimestamp;
     private String endTimestamp;
+    // Include the resourceFileName of test config in the summary:
+    //  perf/**.json, integration/**.json, resiliency/**.json
+    // This facilitates grouping of test runner results on the dashboard.
+    private String resourceFileName;
 
     public String getStartTimestamp() {
       return millisecondsToTimestampString(startTime);
@@ -78,6 +82,14 @@ public class TestRunner {
 
     public String getEndTimestamp() {
       return millisecondsToTimestampString(endTime);
+    }
+
+    public String getResourceFileName() {
+      return resourceFileName;
+    }
+
+    public void setResourceFileName(String resourceFileName) {
+      this.resourceFileName = resourceFileName;
     }
 
     private static String millisecondsToTimestampString(long milliseconds) {
@@ -97,6 +109,7 @@ public class TestRunner {
     this.testScriptResults = new ArrayList<>();
 
     this.summary = new TestRunSummary(UUID.randomUUID().toString());
+    this.summary.setResourceFileName(config.resourceFileName);
   }
 
   protected void executeTestConfiguration() throws Exception {

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -63,10 +63,7 @@ public class TestRunner {
     private String startUserJourneyTimestamp;
     private String endUserJourneyTimestamp;
     private String endTimestamp;
-    // Include the user-provided resourceFileName of test config in the summary:
-    //  perf/**.json, integration/**.json, resiliency/**.json
-    // This can be used to facilitate grouping of test runner results on the dashboard.
-    private String resourceFileName;
+
     // Include user-provided TestSuite name in the summary:
     // This can be used to facilitate grouping of test runner results on the dashboard.
     private String testSuiteName;
@@ -85,14 +82,6 @@ public class TestRunner {
 
     public String getEndTimestamp() {
       return millisecondsToTimestampString(endTime);
-    }
-
-    public String getResourceFileName() {
-      return resourceFileName;
-    }
-
-    public void setResourceFileName(String resourceFileName) {
-      this.resourceFileName = resourceFileName;
     }
 
     public String getTestSuiteName() {
@@ -120,7 +109,6 @@ public class TestRunner {
     this.testScriptResults = new ArrayList<>();
 
     this.summary = new TestRunSummary(UUID.randomUUID().toString());
-    this.summary.setResourceFileName(config.resourceFileName);
   }
 
   protected void executeTestConfiguration() throws Exception {

--- a/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
@@ -46,6 +46,9 @@ public class TestConfiguration implements SpecificationInterface {
     InputStream inputStream =
         FileUtils.getResourceFileHandle(resourceDirectory + "/" + resourceFileName);
     TestConfiguration testConfig = objectMapper.readValue(inputStream, TestConfiguration.class);
+    // Include the resourceFileName of test config in the summary:
+    //  perf/**.json, integration/**.json, resiliency/**.json
+    // This facilitates grouping of test runner results on the dashboard.
     testConfig.resourceFileName = resourceFileName;
 
     // read in the server file

--- a/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
@@ -46,7 +46,7 @@ public class TestConfiguration implements SpecificationInterface {
     InputStream inputStream =
         FileUtils.getResourceFileHandle(resourceDirectory + "/" + resourceFileName);
     TestConfiguration testConfig = objectMapper.readValue(inputStream, TestConfiguration.class);
-    // Include the resourceFileName of test config in the summary:
+    // Include the user-provided resourceFileName of this test configuration:
     //  perf/**.json, integration/**.json, resiliency/**.json
     // This facilitates grouping of test runner results on the dashboard.
     testConfig.resourceFileName = resourceFileName;

--- a/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
@@ -16,6 +16,7 @@ public class TestConfiguration implements SpecificationInterface {
   public String serverSpecificationFile;
   public String billingAccount;
   public boolean isFunctional = false;
+  public String resourceFileName;
   public List<String> testUserFiles;
 
   public ServerSpecification server;
@@ -45,6 +46,7 @@ public class TestConfiguration implements SpecificationInterface {
     InputStream inputStream =
         FileUtils.getResourceFileHandle(resourceDirectory + "/" + resourceFileName);
     TestConfiguration testConfig = objectMapper.readValue(inputStream, TestConfiguration.class);
+    testConfig.resourceFileName = resourceFileName;
 
     // read in the server file
     String serverEnvVarOverride = readServerEnvironmentVariable();


### PR DESCRIPTION
This PR enhances `TestRunner` to include the test configuration file name from `TestSuite` as a new property (`resourceFileName` property) in `TestRunSummary` and `TestConfiguration` classes.

The `resourceFileName` property is of the format

- `perf/**.json`
- `integration/**.json`
- `resiliency/**.json`

etc.

This enhancement facilitates grouping of test runner results on the dashboard.

For a screen shot of the `BigQuery` table with the new `resourceFileName` property, see the Acceptance Criteria section of the Jira ticket [QA-1607.](https://broadworkbench.atlassian.net/browse/QA-1607).

For a trial WSM test run using this new version (`0.0.9-SNAPSHOT`), please refer to workflow [https://github.com/DataBiosphere/terra-workspace-manager/runs/3956951516?check_suite_focus=true](https://github.com/DataBiosphere/terra-workspace-manager/runs/3956951516?check_suite_focus=true).