### PR TITLE
PF-1131: Refactor output POJO classes.

### DIFF
--- a/src/main/java/bio/terra/testrunner/collector/MeasurementCollector.java
+++ b/src/main/java/bio/terra/testrunner/collector/MeasurementCollector.java
@@ -3,6 +3,7 @@ package bio.terra.testrunner.collector;
 import bio.terra.testrunner.collector.config.MeasurementCollectionScriptSpecification;
 import bio.terra.testrunner.collector.config.MeasurementList;
 import bio.terra.testrunner.common.utils.FileUtils;
+import bio.terra.testrunner.runner.TestRunSummary;
 import bio.terra.testrunner.runner.TestRunner;
 import bio.terra.testrunner.runner.config.ServerSpecification;
 import bio.terra.testrunner.runner.config.TestConfiguration;
@@ -162,8 +163,7 @@ public class MeasurementCollector {
       // read in the test config and test run summary files
       TestConfiguration renderedTestConfig =
           TestRunner.getRenderedTestConfiguration(testRunOutputDirectory);
-      TestRunner.TestRunSummary testRunSummary =
-          TestRunner.getTestRunSummary(testRunOutputDirectory);
+      TestRunSummary testRunSummary = TestRunner.getTestRunSummary(testRunOutputDirectory);
 
       if (renderedTestConfig.server.skipKubernetes) {
         logger.warn("The skipKubernetes flag is true, so there may be no measurements to collect.");

--- a/src/main/java/bio/terra/testrunner/runner/TestRunFullOutput.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunFullOutput.java
@@ -1,0 +1,31 @@
+package bio.terra.testrunner.runner;
+
+import bio.terra.testrunner.runner.config.TestConfiguration;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * All output information from a test run is included in this POJO for easier automated processing
+ * (i.e. one file instead of four).
+ */
+@SuppressFBWarnings(
+    value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+    justification = "This POJO class is used for easy serialization to JSON using Jackson.")
+public class TestRunFullOutput {
+  public TestConfiguration testConfiguration;
+  public List<TestScriptResult> testScriptResults;
+  public TestRunSummary testRunSummary;
+  public Map<String, Map<String, String>> componentVersions;
+
+  public TestRunFullOutput(
+      TestConfiguration testConfiguration,
+      List<TestScriptResult> testScriptResults,
+      TestRunSummary testRunSummary,
+      Map<String, Map<String, String>> componentVersions) {
+    this.testConfiguration = testConfiguration;
+    this.testScriptResults = testScriptResults;
+    this.testRunSummary = testRunSummary;
+    this.componentVersions = componentVersions;
+  }
+}

--- a/src/main/java/bio/terra/testrunner/runner/TestRunSummary.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunSummary.java
@@ -1,0 +1,63 @@
+package bio.terra.testrunner.runner;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+public class TestRunSummary {
+  public String id;
+
+  public long startTime = -1;
+  public long startUserJourneyTime = -1;
+  public long endUserJourneyTime = -1;
+  public long endTime = -1;
+  public List<TestScriptResultSummary> testScriptResultSummaries;
+
+  public TestRunSummary() {}
+
+  public TestRunSummary(String id) {
+    this.id = id;
+  }
+
+  private String startTimestamp;
+  private String startUserJourneyTimestamp;
+  private String endUserJourneyTimestamp;
+  private String endTimestamp;
+
+  // Include user-provided TestSuite name in the summary:
+  // This can be used to facilitate grouping of test runner results on the dashboard.
+  private String testSuiteName;
+
+  public String getStartTimestamp() {
+    return millisecondsToTimestampString(startTime);
+  }
+
+  public String getStartUserJourneyTimestamp() {
+    return millisecondsToTimestampString(startUserJourneyTime);
+  }
+
+  public String getEndUserJourneyTimestamp() {
+    return millisecondsToTimestampString(endUserJourneyTime);
+  }
+
+  public String getEndTimestamp() {
+    return millisecondsToTimestampString(endTime);
+  }
+
+  public String getTestSuiteName() {
+    return testSuiteName;
+  }
+
+  public void setTestSuiteName(String testSuiteName) {
+    this.testSuiteName = testSuiteName;
+  }
+
+  private static String millisecondsToTimestampString(long milliseconds) {
+    DateFormat dateFormat =
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS'Z'"); // Quoted Z to indicate UTC
+    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    return dateFormat.format(new Date(milliseconds));
+  }
+}

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -16,8 +16,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
@@ -34,6 +32,7 @@ public class TestRunner {
   private ThreadPoolExecutor disruptionThreadPool;
   private List<List<Future<UserJourneyResult>>> userJourneyFutureLists;
 
+  // test run outputs
   private List<TestScriptResult> testScriptResults;
   protected TestRunSummary summary;
 
@@ -43,62 +42,6 @@ public class TestRunner {
       new HashMap<String, Map<String, String>>();
 
   private boolean exceptionThrownInCleanup = false;
-
-  public static class TestRunSummary {
-    public String id;
-
-    public long startTime = -1;
-    public long startUserJourneyTime = -1;
-    public long endUserJourneyTime = -1;
-    public long endTime = -1;
-    public List<TestScriptResult.TestScriptResultSummary> testScriptResultSummaries;
-
-    public TestRunSummary() {}
-
-    public TestRunSummary(String id) {
-      this.id = id;
-    }
-
-    private String startTimestamp;
-    private String startUserJourneyTimestamp;
-    private String endUserJourneyTimestamp;
-    private String endTimestamp;
-
-    // Include user-provided TestSuite name in the summary:
-    // This can be used to facilitate grouping of test runner results on the dashboard.
-    private String testSuiteName;
-
-    public String getStartTimestamp() {
-      return millisecondsToTimestampString(startTime);
-    }
-
-    public String getStartUserJourneyTimestamp() {
-      return millisecondsToTimestampString(startUserJourneyTime);
-    }
-
-    public String getEndUserJourneyTimestamp() {
-      return millisecondsToTimestampString(endUserJourneyTime);
-    }
-
-    public String getEndTimestamp() {
-      return millisecondsToTimestampString(endTime);
-    }
-
-    public String getTestSuiteName() {
-      return testSuiteName;
-    }
-
-    public void setTestSuiteName(String testSuiteName) {
-      this.testSuiteName = testSuiteName;
-    }
-
-    private static String millisecondsToTimestampString(long milliseconds) {
-      DateFormat dateFormat =
-          new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS'Z'"); // Quoted Z to indicate UTC
-      dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-      return dateFormat.format(new Date(milliseconds));
-    }
-  }
 
   protected TestRunner(TestConfiguration config) {
     this.config = config;
@@ -573,9 +516,9 @@ public class TestRunner {
    * Read in the test run summary from the output directory and return the TestRunner.TestRunSummary
    * Java object.
    */
-  public static TestRunner.TestRunSummary getTestRunSummary(Path outputDirectory) throws Exception {
+  public static TestRunSummary getTestRunSummary(Path outputDirectory) throws Exception {
     return FileUtils.readOutputFileIntoJavaObject(
-        outputDirectory, TestRunner.runSummaryFileName, TestRunner.TestRunSummary.class);
+        outputDirectory, TestRunner.runSummaryFileName, TestRunSummary.class);
   }
 
   /**
@@ -594,7 +537,7 @@ public class TestRunner {
 
     // build a list of output directories that contain test run results
     List<Path> testRunOutputDirectories = new ArrayList<>();
-    TestRunner.TestRunSummary testRunSummary = null;
+    TestRunSummary testRunSummary = null;
     try {
       testRunSummary = getTestRunSummary(outputDirectory);
     } catch (Exception ex) {
@@ -662,7 +605,7 @@ public class TestRunner {
 
         // even if the test configuration didn't throw an exception, it still may have failed due to
         // a timeout
-        for (TestScriptResult.TestScriptResultSummary testScriptResultSummary :
+        for (TestScriptResultSummary testScriptResultSummary :
             runner.summary.testScriptResultSummaries) {
           if (testScriptResultSummary.isFailure) {
             testConfigFailed = true;

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -430,6 +430,7 @@ public class TestRunner {
   private static final String userJourneyResultsFileName = "RAWDATA_userJourneyResults.json";
   private static final String runSummaryFileName = "SUMMARY_testRun.json";
   private static final String envVersionFileName = "ENV_componentVersion.json";
+  private static final String fullOutputFileName = "FULL_testRunOutput.json";
 
   /** Helper method to write out the results to files at the end of a test configuration run. */
   protected void writeOutResults(String outputParentDirName) throws IOException {
@@ -461,6 +462,7 @@ public class TestRunner {
         FileUtils.createNewFile(outputDirectory.resolve(userJourneyResultsFileName).toFile());
     File runSummaryFile = outputDirectory.resolve(runSummaryFileName).toFile();
     File terraVersionFile = outputDirectory.resolve(envVersionFileName).toFile();
+    File runFullOutputFile = outputDirectory.resolve(fullOutputFileName).toFile();
 
     // write the rendered test configuration that was run to a file
     objectWriter.writeValue(renderedConfigFile, config);
@@ -477,6 +479,11 @@ public class TestRunner {
     // Write the MCTerra Component versions of target environment to a file
     objectWriter.writeValue(terraVersionFile, componentVersions);
     logger.info("MCTerra Component versions written to file: {}", terraVersionFile.getName());
+
+    // write full output to a single file for easier automated processing
+    TestRunFullOutput runFullOutput =
+        new TestRunFullOutput(config, testScriptResults, summary, componentVersions);
+    objectWriter.writeValue(runFullOutputFile, runFullOutput);
   }
 
   /** Helper method to print out the PASSED/FAILED tests at the end of a suite run. */

--- a/src/main/java/bio/terra/testrunner/runner/TestScriptResult.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestScriptResult.java
@@ -2,41 +2,12 @@ package bio.terra.testrunner.runner;
 
 import bio.terra.testrunner.common.BasicStatistics;
 import bio.terra.testrunner.runner.config.TestScriptSpecification;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 
 public class TestScriptResult {
   public List<UserJourneyResult> userJourneyResults;
   public TestScriptResultSummary summary;
-
-  /**
-   * Summary statistics are pulled out into a separate inner class for easier summary reporting.
-   * This class does not include a reference to the full TestScriptSpecification or the list of
-   * UserJourneyResults.
-   */
-  @SuppressFBWarnings(
-      value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
-      justification = "This POJO class is used for easy serialization to JSON using Jackson.")
-  public static class TestScriptResultSummary {
-    public String testScriptName;
-    public String testScriptDescription;
-
-    public BasicStatistics elapsedTimeStatistics;
-
-    public int totalRun; // total number of user journey threads submitted to the thread pool
-    public int numCompleted; // number of user journey threads that completed
-    public int numExceptionsThrown; // number of user journey threads that threw exceptions
-
-    public boolean isFailure; // numCompleted < totalRun
-
-    public TestScriptResultSummary() {} // default constructor so Jackson can deserialize
-
-    private TestScriptResultSummary(String testScriptName, String testScriptDescription) {
-      this.testScriptName = testScriptName;
-      this.testScriptDescription = testScriptDescription;
-    }
-  }
 
   public TestScriptResult(
       TestScriptSpecification testScriptSpecification, List<UserJourneyResult> userJourneyResults) {

--- a/src/main/java/bio/terra/testrunner/runner/TestScriptResultSummary.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestScriptResultSummary.java
@@ -1,0 +1,28 @@
+package bio.terra.testrunner.runner;
+
+import bio.terra.testrunner.common.BasicStatistics;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/** Summary statistics are pulled out into a separate class for easier summary reporting. */
+@SuppressFBWarnings(
+    value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+    justification = "This POJO class is used for easy serialization to JSON using Jackson.")
+public class TestScriptResultSummary {
+  public String testScriptName;
+  public String testScriptDescription;
+
+  public BasicStatistics elapsedTimeStatistics;
+
+  public int totalRun; // total number of user journey threads submitted to the thread pool
+  public int numCompleted; // number of user journey threads that completed
+  public int numExceptionsThrown; // number of user journey threads that threw exceptions
+
+  public boolean isFailure; // numCompleted < totalRun
+
+  public TestScriptResultSummary() {} // default constructor so Jackson can deserialize
+
+  TestScriptResultSummary(String testScriptName, String testScriptDescription) {
+    this.testScriptName = testScriptName;
+    this.testScriptDescription = testScriptDescription;
+  }
+}

--- a/src/main/java/scripts/uploadscripts/CompressDirectoryToBucket.java
+++ b/src/main/java/scripts/uploadscripts/CompressDirectoryToBucket.java
@@ -2,6 +2,7 @@ package scripts.uploadscripts;
 
 import bio.terra.testrunner.common.utils.FileUtils;
 import bio.terra.testrunner.common.utils.StorageUtils;
+import bio.terra.testrunner.runner.TestRunSummary;
 import bio.terra.testrunner.runner.TestRunner;
 import bio.terra.testrunner.runner.config.ServiceAccountSpecification;
 import bio.terra.testrunner.uploader.UploadScript;
@@ -59,7 +60,7 @@ public class CompressDirectoryToBucket extends UploadScript {
           "Parent directory of the directory to compress is null: "
               + outputDirectory.toAbsolutePath());
     }
-    TestRunner.TestRunSummary testRunSummary = TestRunner.getTestRunSummary(outputDirectory);
+    TestRunSummary testRunSummary = TestRunner.getTestRunSummary(outputDirectory);
     String archiveFileName = testRunSummary.id + ".tar.gz";
     Path archiveFile = outputDirectoryParent.resolve(archiveFileName);
 

--- a/src/main/java/scripts/uploadscripts/SummariesToBigQuery.java
+++ b/src/main/java/scripts/uploadscripts/SummariesToBigQuery.java
@@ -3,8 +3,9 @@ package scripts.uploadscripts;
 import bio.terra.testrunner.collector.MeasurementCollectionScript;
 import bio.terra.testrunner.collector.MeasurementCollector;
 import bio.terra.testrunner.common.utils.BigQueryUtils;
+import bio.terra.testrunner.runner.TestRunSummary;
 import bio.terra.testrunner.runner.TestRunner;
-import bio.terra.testrunner.runner.TestScriptResult;
+import bio.terra.testrunner.runner.TestScriptResultSummary;
 import bio.terra.testrunner.runner.config.ServiceAccountSpecification;
 import bio.terra.testrunner.runner.config.TestConfiguration;
 import bio.terra.testrunner.runner.config.TestScriptSpecification;
@@ -40,7 +41,7 @@ public class SummariesToBigQuery extends UploadScript {
   protected String datasetName; // big query dataset name
 
   protected TestConfiguration renderedTestConfiguration;
-  protected TestRunner.TestRunSummary testRunSummary;
+  protected TestRunSummary testRunSummary;
   protected MeasurementCollectionScript.MeasurementResultSummary[] measurementCollectionSummaries;
 
   /**
@@ -98,8 +99,8 @@ public class SummariesToBigQuery extends UploadScript {
     tableId = TableId.of(datasetName, testScriptResultsTableName);
     InsertAllRequest.Builder insertRequestBuilder = InsertAllRequest.newBuilder(tableId);
     // Store test summaries in a Map with test names as keys
-    Map<String, TestScriptResult.TestScriptResultSummary> testScriptResultSummaries =
-        new ConcurrentHashMap<String, TestScriptResult.TestScriptResultSummary>();
+    Map<String, TestScriptResultSummary> testScriptResultSummaries =
+        new ConcurrentHashMap<String, TestScriptResultSummary>();
     testRunSummary.testScriptResultSummaries.stream()
         .forEach(
             runSummary -> testScriptResultSummaries.put(runSummary.testScriptName, runSummary));
@@ -157,8 +158,7 @@ public class SummariesToBigQuery extends UploadScript {
 
   /** Build a single row for each test script result. */
   private Map<String, Object> buildTestScriptResultsRow(
-      TestScriptSpecification testScriptSpecification,
-      TestScriptResult.TestScriptResultSummary testScriptResult) {
+      TestScriptSpecification testScriptSpecification, TestScriptResultSummary testScriptResult) {
     Map<String, Object> rowContent = new HashMap<>();
 
     rowContent.put("testRun_id", testRunSummary.id);


### PR DESCRIPTION
- Pull out all output POJOs into their own classes. At least a couple are defined as internal static classes.
- Define a new POJO class that includes all output information. Write this consolidated format out to a new output file.

Main goal of these small changes is code cleanup in preparation for a discussion with Ivan about reorganizing the output format to better accommodate the behavior of the QA CloudFunction that streams test results to BQ.