### PR TITLE
[PF-1246] Force update transitive log4j dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,18 @@ dependencies {
     implementation group: 'com.google.apis', name: 'google-api-services-container', version: "${googleContainer}"
 
     implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: "${jgit}"
+
+    // Force transitive log4j version to at least 2.15.0 for security concerns.
+    implementation('org.apache.logging.log4j:log4j-api') {
+        version {
+            require "2.15.0"
+        }
+    }
+    implementation('org.apache.logging.log4j:log4j-to-slf4j') {
+        version {
+            require "2.15.0"
+        }
+    }
 }
 
 test {


### PR DESCRIPTION
Force transitive log4j api and slf4j library dependencies to the latest version due to security concerns. We do not use log4j core, so nothing to update there.