### PR TITLE
[PF-1251] Bump log4j api to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,15 +74,15 @@ dependencies {
 
     implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: "${jgit}"
 
-    // Force transitive log4j version to at least 2.15.0 for security concerns.
+    // Force transitive log4j version to at least 2.16.0 for security concerns.
     implementation('org.apache.logging.log4j:log4j-api') {
         version {
-            require "2.15.0"
+            require "2.16.0"
         }
     }
     implementation('org.apache.logging.log4j:log4j-to-slf4j') {
         version {
-            require "2.15.0"
+            require "2.16.0"
         }
     }
 }


### PR DESCRIPTION
Bump log4j-api transitive dependency version from 2.15.0 to 2.16.0.