### PR TITLE
[PF-1260] Log4j version to 2.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,15 +74,15 @@ dependencies {
 
     implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: "${jgit}"
 
-    // Force transitive log4j version to at least 2.16.0 for security concerns.
+    // Force transitive log4j version to at least 2.17.0 for security concerns.
     implementation('org.apache.logging.log4j:log4j-api') {
         version {
-            require "2.16.0"
+            require "2.17.0"
         }
     }
     implementation('org.apache.logging.log4j:log4j-to-slf4j') {
         version {
-            require "2.16.0"
+            require "2.17.0"
         }
     }
 }


### PR DESCRIPTION
Update log4j-api and log4j-to-slf4j dependencies to version 2.17. This service does not use log4j-core.