### PR TITLE
Renamed all instances of parameters to parametersMap 

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,9 @@ start a local Data Repo server by executing the Gradle bootRun task from that
 directory. This is useful for debugging or testing local server code changes.
 
 You need to modify the path for your own machine. See
-deploymentScript.parameters below.
+deploymentScript.parameters (version 0.1.2-SNAPSHOT or below) or deploymentScript.parametersMap (version 0.1.3-SNAPSHOT or above).
 
+For version up to 0.1.2-SNAPSHOT
 ```json
 {
   "name": "localhost",
@@ -235,6 +236,24 @@ deploymentScript.parameters below.
   "deploymentScript": {
     "name": "LaunchLocalProcess",
     "parameters": {
+      "tdr-file-path": "file:///Users/marikomedlock/Workspaces/jade-data-repo/"
+    }
+  },
+  "skipDeployment": false,
+  "skipKubernetes": true
+}
+```
+For version up to 0.1.3-SNAPSHOT or above
+```json
+{
+  "name": "localhost",
+  "description": "Server running locally. Supports launching the server in a separate process. Does not support modifying Kubernetes post-deployment.",
+  "datarepoUri": "http://localhost:8080/",
+  "samUri": "https://sam.dsde-dev.broadinstitute.org",
+  "samResourceIdForDatarepo": "broad-jade-dev",
+  "deploymentScript": {
+    "name": "LaunchLocalProcess",
+    "parametersMap": {
       "tdr-file-path": "file:///Users/marikomedlock/Workspaces/jade-data-repo/"
     }
   },
@@ -705,7 +724,8 @@ available fields:
   fields:
     * name: Name of the measurement collection script class to run
     * description: Description of the parametrized metric
-    * parameters: (optional) parameters to pass to the metric collection script
+    * parameters: (optional) parameters to pass to the metric collection script (up to version 0.1.2-SNAPSHOT, replaced with parametersMap since version 0.1.3-SNAPSHOT)
+    * parametersMap: (optional) parametersMap to pass to the metric collection script (version 0.1.3-SNAPSHOT or above)
 
 ## Development
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.1.2-SNAPSHOT'
+version '0.1.3-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')

--- a/src/main/java/bio/terra/testrunner/collector/MeasurementCollectionScript.java
+++ b/src/main/java/bio/terra/testrunner/collector/MeasurementCollectionScript.java
@@ -64,9 +64,10 @@ public abstract class MeasurementCollectionScript<T> {
    * be set by the Measurement Collector based on the current Measurement List, and can be used by
    * the measurement collection script methods.
    *
-   * @param parameters map of string key-value pairs supplied by the measurement collection script
+   * @param parametersMap map of string key-value pairs supplied by the measurement collection
+   *     script
    */
-  public void setParameters(Map<String, String> parameters) throws Exception {}
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {}
 
   /** The class generic parameter specifies the type of a single raw data point. */
   protected List<T> dataPoints;

--- a/src/main/java/bio/terra/testrunner/collector/MeasurementCollector.java
+++ b/src/main/java/bio/terra/testrunner/collector/MeasurementCollector.java
@@ -49,7 +49,7 @@ public class MeasurementCollector {
       // setup an instance of each measurement script class
       MeasurementCollectionScript script = specification.scriptClassInstance();
       script.initialize(server, specification.description, specification.saveRawDataPoints);
-      script.setParameters(specification.parameters);
+      script.setParametersMap(specification.parametersMap);
 
       // download raw data points and process them
       logger.info("Executing measurement collection script: {}", specification.description);

--- a/src/main/java/bio/terra/testrunner/collector/config/MeasurementCollectionScriptSpecification.java
+++ b/src/main/java/bio/terra/testrunner/collector/config/MeasurementCollectionScriptSpecification.java
@@ -1,8 +1,12 @@
 package bio.terra.testrunner.collector.config;
 
 import bio.terra.testrunner.collector.MeasurementCollectionScript;
+import bio.terra.testrunner.common.utils.LogsUtils;
 import bio.terra.testrunner.runner.config.SpecificationInterface;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 @SuppressFBWarnings(
@@ -11,7 +15,10 @@ import java.util.Map;
 public class MeasurementCollectionScriptSpecification implements SpecificationInterface {
   public String name;
   public String description;
-  public Map<String, String> parameters;
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  public Map<String, String> parametersMap;
+
   public boolean saveRawDataPoints;
 
   private MeasurementCollectionScript scriptClassInstance;
@@ -41,5 +48,15 @@ public class MeasurementCollectionScriptSpecification implements SpecificationIn
       throw new IllegalArgumentException(
           "Error calling constructor of MeasurementCollectionScript class: " + name, niEx);
     }
+  }
+
+  /**
+   * Return parametersMap as a JSON string
+   *
+   * @return a Java String
+   */
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  public List<String> getParameters() {
+    return Arrays.asList(new String[] {LogsUtils.parametersToString(parametersMap)});
   }
 }

--- a/src/main/java/bio/terra/testrunner/common/utils/LogsUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/LogsUtils.java
@@ -125,6 +125,7 @@ public class LogsUtils {
   /** Build a pretty description string from a map of key:value parameter pairs. */
   public static String parametersToString(Map<String, String> params) {
     StringBuilder sb = new StringBuilder();
+    if (params == null || params.keySet().isEmpty()) return "{}";
     for (Map.Entry<String, String> param : params.entrySet()) {
       sb.append("{").append(param.getKey()).append(": ").append(param.getValue()).append("},");
     }

--- a/src/main/java/bio/terra/testrunner/runner/DeploymentScript.java
+++ b/src/main/java/bio/terra/testrunner/runner/DeploymentScript.java
@@ -13,9 +13,10 @@ public abstract class DeploymentScript {
    * the Test Runner based on the current Test Configuration, and can be used by the Deployment
    * script methods.
    *
-   * @param parameters map of string key-value pairs supplied by the test configuration
+   * @param parametersMap map of string key-value pairs supplied by the server.deploymentScript
+   *     configuration
    */
-  public void setParameters(Map<String, String> parameters) throws Exception {}
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {}
 
   /** The deployment script deploy method kicks off the deployment. */
   public void deploy(ServerSpecification server, ApplicationSpecification app) throws Exception {

--- a/src/main/java/bio/terra/testrunner/runner/DisruptiveScript.java
+++ b/src/main/java/bio/terra/testrunner/runner/DisruptiveScript.java
@@ -57,9 +57,9 @@ public abstract class DisruptiveScript {
    * Test Runner based on the current Test Configuration, and can be used by the Disruptive script
    * methods.
    *
-   * @param parameters map of string key-value pairs supplied by the test configuration
+   * @param parametersMap map of string key-value pairs supplied by the test configuration
    */
-  public void setParameters(Map<String, String> parameters) throws Exception {}
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {}
 
   /**
    * The test script disrupt method contains the actions we want to perform in order disrupt the

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -112,7 +112,7 @@ public class TestRunner {
       }
 
       // set any parameters specified by the configuration
-      deploymentScript.setParameters(config.server.deploymentScript.parameters);
+      deploymentScript.setParametersMap(config.server.deploymentScript.parametersMap);
 
       // call the deploy and waitForDeployToFinish methods to do the deployment
       logger.info("Deployment: Calling {}.deploy()", deploymentScript.getClass().getName());
@@ -138,7 +138,7 @@ public class TestRunner {
       for (VersionScriptSpecification spec : config.server.versionScripts) {
         VersionScript versionScript = spec.scriptClass.getDeclaredConstructor().newInstance();
         logger.info("Version: Instantiated {} class", versionScript.getClass().getName());
-        versionScript.setParameters(spec.parameters);
+        versionScript.setParametersMap(spec.parametersMap);
         if (versionScripts == null) {
           versionScripts = new ArrayList<>();
         }
@@ -167,7 +167,7 @@ public class TestRunner {
       testScriptInstance.setServer(config.server);
 
       // set any parameters specified by the configuration
-      testScriptInstance.setParameters(testScriptSpecification.parameters);
+      testScriptInstance.setParametersMap(testScriptSpecification.parametersMap);
 
       scripts.add(testScriptInstance);
     }
@@ -187,7 +187,7 @@ public class TestRunner {
           config.disruptiveScript.disruptiveScriptClassInstance();
       disruptiveScriptInstance.setBillingAccount(config.billingAccount);
       disruptiveScriptInstance.setServer(config.server);
-      disruptiveScriptInstance.setParameters(config.disruptiveScript.parameters);
+      disruptiveScriptInstance.setParametersMap(config.disruptiveScript.parametersMap);
 
       // create a thread pool for running its disrupt method
       disruptionThreadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(1);

--- a/src/main/java/bio/terra/testrunner/runner/TestScript.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestScript.java
@@ -54,9 +54,10 @@ public abstract class TestScript {
    * Setter for any parameters required by the test script. These parameters will be set by the Test
    * Runner based on the current Test Configuration, and can be used by the Test script methods.
    *
-   * @param parameters map of string key-value pairs, parameters supplied by the test configuration
+   * @param parametersMap map of string key-value pairs, parameters supplied by the test
+   *     configuration
    */
-  public void setParameters(Map<String, String> parameters) throws Exception {}
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {}
 
   /**
    * The test script setup contains the API call(s) that we do not want to profile and will not be

--- a/src/main/java/bio/terra/testrunner/runner/VersionScript.java
+++ b/src/main/java/bio/terra/testrunner/runner/VersionScript.java
@@ -12,9 +12,10 @@ public abstract class VersionScript {
    * Test Runner based on the current Test Configuration, and can be used by the Version script
    * methods.
    *
-   * @param parameters map of string key-value pairs supplied by the test configuration
+   * @param parametersMap map of string key-value pairs supplied by the server.versionScripts
+   *     configuration
    */
-  public void setParameters(Map<String, String> parameters) throws Exception {}
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {}
 
   /** The version script determineVersion method looks up the version. */
   public VersionScriptResult determineVersion(ServerSpecification server) throws Exception {

--- a/src/main/java/bio/terra/testrunner/runner/config/DeploymentScriptSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/DeploymentScriptSpecification.java
@@ -1,12 +1,18 @@
 package bio.terra.testrunner.runner.config;
 
+import bio.terra.testrunner.common.utils.LogsUtils;
 import bio.terra.testrunner.runner.DeploymentScript;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class DeploymentScriptSpecification implements SpecificationInterface {
   public String name = "";
-  public Map<String, String> parameters = new HashMap<>();
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  public Map<String, String> parametersMap = new HashMap<>();
 
   public Class<? extends DeploymentScript> scriptClass;
 
@@ -25,5 +31,15 @@ public class DeploymentScriptSpecification implements SpecificationInterface {
     } catch (ClassNotFoundException | ClassCastException classEx) {
       throw new IllegalArgumentException("Deployment script class not found: " + name, classEx);
     }
+  }
+
+  /**
+   * Return parametersMap as a JSON string
+   *
+   * @return a Java String
+   */
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  public List<String> getParameters() {
+    return Arrays.asList(new String[] {LogsUtils.parametersToString(parametersMap)});
   }
 }

--- a/src/main/java/bio/terra/testrunner/runner/config/DisruptiveScriptSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/DisruptiveScriptSpecification.java
@@ -1,7 +1,11 @@
 package bio.terra.testrunner.runner.config;
 
+import bio.terra.testrunner.common.utils.LogsUtils;
 import bio.terra.testrunner.runner.DisruptiveScript;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 @SuppressFBWarnings(
@@ -9,7 +13,9 @@ import java.util.Map;
     justification = "This POJO class is used for easy serialization to JSON using Jackson.")
 public class DisruptiveScriptSpecification implements SpecificationInterface {
   public String name;
-  public Map<String, String> parameters;
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  public Map<String, String> parametersMap;
 
   private DisruptiveScript disruptiveScriptClassInstance;
 
@@ -33,5 +39,15 @@ public class DisruptiveScriptSpecification implements SpecificationInterface {
       throw new IllegalArgumentException(
           "Error calling constructor of Disruptive Script class: " + name, niEx);
     }
+  }
+
+  /**
+   * Return parametersMap as a JSON string
+   *
+   * @return a Java String
+   */
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  public List<String> getParameters() {
+    return Arrays.asList(new String[] {LogsUtils.parametersToString(parametersMap)});
   }
 }

--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -1,6 +1,7 @@
 package bio.terra.testrunner.runner.config;
 
 import bio.terra.testrunner.common.utils.FileUtils;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.util.List;
@@ -42,12 +43,15 @@ public class ServerSpecification implements SpecificationInterface {
   public String workspaceManagerUri;
 
   // External Credentials Manager
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   public String externalCredentialsManagerUri;
 
   // Drs Hub
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   public String drsHubUri;
 
   // Catalog Service
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   public String catalogUri;
 
   // =============================================

--- a/src/main/java/bio/terra/testrunner/runner/config/TestScriptSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/TestScriptSpecification.java
@@ -2,7 +2,10 @@ package bio.terra.testrunner.runner.config;
 
 import bio.terra.testrunner.common.utils.LogsUtils;
 import bio.terra.testrunner.runner.TestScript;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -15,7 +18,9 @@ public class TestScriptSpecification implements SpecificationInterface {
   public int userJourneyThreadPoolSize = 1;
   public long expectedTimeForEach;
   public String expectedTimeForEachUnit;
-  public Map<String, String> parameters;
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  public Map<String, String> parametersMap;
 
   private TestScript scriptClassInstance;
   public TimeUnit expectedTimeForEachUnitObj;
@@ -59,8 +64,18 @@ public class TestScriptSpecification implements SpecificationInterface {
 
     // generate a separate description property that also includes any test script parameters
     description = name;
-    if (parameters != null) {
-      description += ": " + LogsUtils.parametersToString(parameters);
+    if (parametersMap != null) {
+      description += ": " + LogsUtils.parametersToString(parametersMap);
     }
+  }
+
+  /**
+   * Return parametersMap as a JSON string
+   *
+   * @return a Java String
+   */
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  public List<String> getParameters() {
+    return Arrays.asList(new String[] {LogsUtils.parametersToString(parametersMap)});
   }
 }

--- a/src/main/java/bio/terra/testrunner/runner/config/VersionScriptSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/VersionScriptSpecification.java
@@ -1,8 +1,12 @@
 package bio.terra.testrunner.runner.config;
 
+import bio.terra.testrunner.common.utils.LogsUtils;
 import bio.terra.testrunner.runner.VersionScript;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @SuppressFBWarnings(
@@ -10,7 +14,10 @@ import java.util.Map;
     justification = "This POJO class is used for easy serialization to JSON using Jackson.")
 public class VersionScriptSpecification implements SpecificationInterface {
   public String name = "";
-  public Map<String, String> parameters = new HashMap<>();
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  public Map<String, String> parametersMap = new HashMap<>();
+
   public String description;
 
   public Class<? extends VersionScript> scriptClass;
@@ -30,5 +37,15 @@ public class VersionScriptSpecification implements SpecificationInterface {
     } catch (ClassNotFoundException | ClassCastException classEx) {
       throw new IllegalArgumentException("Version script class not found: " + name, classEx);
     }
+  }
+
+  /**
+   * Return parametersMap as a JSON string
+   *
+   * @return a Java String
+   */
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  public List<String> getParameters() {
+    return Arrays.asList(new String[] {LogsUtils.parametersToString(parametersMap)});
   }
 }

--- a/src/main/java/bio/terra/testrunner/uploader/ResultUploader.java
+++ b/src/main/java/bio/terra/testrunner/uploader/ResultUploader.java
@@ -25,7 +25,7 @@ public class ResultUploader {
     for (UploadScriptSpecification specification : uploadList.uploadScripts) {
       // setup an instance of each upload script class
       UploadScript script = specification.scriptClassInstance();
-      script.setParameters(specification.parameters);
+      script.setParametersMap(specification.parametersMap);
 
       // upload the results somewhere
       logger.info("Executing upload script: {}", specification.description);

--- a/src/main/java/bio/terra/testrunner/uploader/UploadScript.java
+++ b/src/main/java/bio/terra/testrunner/uploader/UploadScript.java
@@ -16,9 +16,9 @@ public abstract class UploadScript {
    * Setter for any parameters required by the upload script. These parameters will be set by the
    * Result Uploader based on the current Upload List, and can be used by the upload script methods.
    *
-   * @param parameters map of string key-value pairs supplied by the upload list
+   * @param parametersMap map of string key-value pairs supplied by the upload list
    */
-  public void setParameters(Map<String, String> parameters) throws Exception {}
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {}
 
   /**
    * Upload the test results saved to the given directory. Results may include Test Runner

--- a/src/main/java/bio/terra/testrunner/uploader/config/UploadScriptSpecification.java
+++ b/src/main/java/bio/terra/testrunner/uploader/config/UploadScriptSpecification.java
@@ -1,8 +1,12 @@
 package bio.terra.testrunner.uploader.config;
 
+import bio.terra.testrunner.common.utils.LogsUtils;
 import bio.terra.testrunner.runner.config.SpecificationInterface;
 import bio.terra.testrunner.uploader.UploadScript;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 @SuppressFBWarnings(
@@ -11,7 +15,9 @@ import java.util.Map;
 public class UploadScriptSpecification implements SpecificationInterface {
   public String name;
   public String description;
-  public Map<String, String> parameters;
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  public Map<String, String> parametersMap;
 
   private UploadScript scriptClassInstance;
 
@@ -39,5 +45,14 @@ public class UploadScriptSpecification implements SpecificationInterface {
       throw new IllegalArgumentException(
           "Error calling constructor of UploadScript class: " + name, niEx);
     }
+  }
+  /**
+   * Return parametersMap as a JSON string
+   *
+   * @return a Java String
+   */
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  public List<String> getParameters() {
+    return Arrays.asList(new String[] {LogsUtils.parametersToString(parametersMap)});
   }
 }

--- a/src/main/java/scripts/uploadscripts/CompressDirectoryToBucket.java
+++ b/src/main/java/scripts/uploadscripts/CompressDirectoryToBucket.java
@@ -33,13 +33,13 @@ public class CompressDirectoryToBucket extends UploadScript {
    * Setter for any parameters required by the upload script. These parameters will be set by the
    * Result Uploader based on the current Upload List, and can be used by the upload script methods.
    *
-   * @param parameters list of string parameters supplied by the upload list
+   * @param parametersMap lmap of string key-value pairs supplied by the upload list
    */
-  public void setParameters(Map<String, String> parameters) throws Exception {
-    if (parameters == null || !parameters.containsKey(BUCKET_PATH_PARAMETER_KEY)) {
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {
+    if (parametersMap == null || !parametersMap.containsKey(BUCKET_PATH_PARAMETER_KEY)) {
       throw new IllegalArgumentException("Must provide bucket-path in the parameters list");
     }
-    bucketPath = parameters.get(BUCKET_PATH_PARAMETER_KEY);
+    bucketPath = parametersMap.get(BUCKET_PATH_PARAMETER_KEY);
     if (!bucketPath.startsWith("gs://")) { // only handle GCS buckets
       throw new IllegalArgumentException("Bucket path must start with gs://");
     }

--- a/src/main/java/scripts/uploadscripts/SummariesToBigQuery.java
+++ b/src/main/java/scripts/uploadscripts/SummariesToBigQuery.java
@@ -50,18 +50,18 @@ public class SummariesToBigQuery extends UploadScript {
    * Setter for any parameters required by the upload script. These parameters will be set by the
    * Result Uploader based on the current Upload List, and can be used by the upload script methods.
    *
-   * @param parameters list of string parameters supplied by the upload list
+   * @param parametersMap map of string key-value pairs supplied by the upload list
    */
   @Override
-  public void setParameters(Map<String, String> parameters) throws Exception {
-    if (parameters == null
-        || !parameters.containsKey(BQ_PROJECT_ID_PARAMETER_KEY)
-        || !parameters.containsKey(BQ_DATASET_NAME_PARAMETER_KEY)) {
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {
+    if (parametersMap == null
+        || !parametersMap.containsKey(BQ_PROJECT_ID_PARAMETER_KEY)
+        || !parametersMap.containsKey(BQ_DATASET_NAME_PARAMETER_KEY)) {
       throw new IllegalArgumentException(
           "Must provide BigQuery project-id and dataset-name keys in the parameters list");
     }
-    projectId = parameters.get(BQ_PROJECT_ID_PARAMETER_KEY);
-    datasetName = parameters.get(BQ_DATASET_NAME_PARAMETER_KEY);
+    projectId = parametersMap.get(BQ_PROJECT_ID_PARAMETER_KEY);
+    datasetName = parametersMap.get(BQ_DATASET_NAME_PARAMETER_KEY);
   }
 
   private static String testRunTableName = "testRun";
@@ -173,7 +173,7 @@ public class SummariesToBigQuery extends UploadScript {
     rowContent.put("userJourneyThreadPoolSize", testScriptSpecification.userJourneyThreadPoolSize);
     rowContent.put("expectedTimeForEach", testScriptSpecification.expectedTimeForEach);
     rowContent.put("expectedTimeForEachUnit", testScriptSpecification.expectedTimeForEachUnit);
-    rowContent.put("parameters", testScriptSpecification.parameters);
+    rowContent.put("parameters", testScriptSpecification.getParameters());
 
     rowContent.put("description", testScriptResult.testScriptDescription);
     rowContent.put("elapsedTime_min", testScriptResult.elapsedTimeStatistics.min);

--- a/src/main/java/scripts/versionscripts/ReadFromGitCommitLog.java
+++ b/src/main/java/scripts/versionscripts/ReadFromGitCommitLog.java
@@ -26,15 +26,16 @@ public class ReadFromGitCommitLog extends VersionScript {
    * Test Runner based on the current Test Configuration, and can be used by the version script
    * methods.
    *
-   * @param parameters list of string parameters supplied by the version list
+   * @param parametersMap map of string key-value pairs supplied by the server.versionScripts
+   *     configuration
    */
   @Override
-  public void setParameters(Map<String, String> parameters) throws Exception {
-    if (parameters == null || !parameters.containsKey(GIT_DIR_PARAMETER_KEY)) {
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {
+    if (parametersMap == null || !parametersMap.containsKey(GIT_DIR_PARAMETER_KEY)) {
       throw new IllegalArgumentException(
           "Must provide file path of local .git as git-dir in the parameters list");
     }
-    gitDir = parameters.get(GIT_DIR_PARAMETER_KEY);
+    gitDir = parametersMap.get(GIT_DIR_PARAMETER_KEY);
   }
 
   /** This method determines the version by reading the versions from Git commit log. */

--- a/src/main/java/scripts/versionscripts/ReadFromTerraHelmfileRepo.java
+++ b/src/main/java/scripts/versionscripts/ReadFromTerraHelmfileRepo.java
@@ -30,20 +30,21 @@ public class ReadFromTerraHelmfileRepo extends VersionScript {
    * Test Runner based on the current Test Configuration, and can be used by the version script
    * methods.
    *
-   * @param parameters list of string parameters supplied by the version list
+   * @param parametersMap map of string key-value pairs supplied by the server.versionScripts
+   *     configuration
    */
   @Override
-  public void setParameters(Map<String, String> parameters) throws Exception {
-    if (parameters == null
-        || !parameters.containsKey(APP_NAME_PARAMETER_KEY)
-        || !parameters.containsKey(BASE_FILE_PATH_PARAMETER_KEY)
-        || !parameters.containsKey(OVERRIDE_FILE_PATH_PARAMETER_KEY)) {
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {
+    if (parametersMap == null
+        || !parametersMap.containsKey(APP_NAME_PARAMETER_KEY)
+        || !parametersMap.containsKey(BASE_FILE_PATH_PARAMETER_KEY)
+        || !parametersMap.containsKey(OVERRIDE_FILE_PATH_PARAMETER_KEY)) {
       throw new IllegalArgumentException(
           "Must provide app-name, base-file-path, and override-file-path as parameters");
     }
-    appName = parameters.get(APP_NAME_PARAMETER_KEY);
-    baseFilePath = parameters.get(BASE_FILE_PATH_PARAMETER_KEY);
-    overrideFilePath = parameters.get(OVERRIDE_FILE_PATH_PARAMETER_KEY);
+    appName = parametersMap.get(APP_NAME_PARAMETER_KEY);
+    baseFilePath = parametersMap.get(BASE_FILE_PATH_PARAMETER_KEY);
+    overrideFilePath = parametersMap.get(OVERRIDE_FILE_PATH_PARAMETER_KEY);
   }
 
   /**


### PR DESCRIPTION
Renamed all instances of `parameters` to `parametersMap` and set the new `parametersMap` access to WRITE_ONLY to expose it to scripts using `TestRunner`. The original `parameters` properties are now READ_ONLY and will be used for solely for interfacing with test reporting.

Bump version to 0.1.3-SNAPSHOT.