### PR TITLE
[PF-1531] Switch to apache lang3, add explicit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ repositories {
 dependencies {
     ext {
         apacheMath = '3.6.1'
+        apacheLang = '3.12.0'
         findbugsAnnotations = "3.0.1"
         jackson = '2.11.3'
         kubernetesClient = '10.0.0'
@@ -58,6 +59,7 @@ dependencies {
     }
 
     implementation group: 'org.apache.commons', name: 'commons-math3', version: "${apacheMath}"
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${apacheLang}"
     compileOnly "com.google.code.findbugs:annotations:${findbugsAnnotations}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: "${jackson}"
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: "${jackson}"

--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -4,7 +4,7 @@ import bio.terra.testrunner.common.utils.FileUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * An instance of this class represents a single Terra environment or deployment. It contains all


### PR DESCRIPTION
This switches the last place this library uses the Apache Commons Lang 2 library to 3 (several other classes here already use `org.apache.commons.lang3`). I've also added this as a direct dependency since we use it directly.

The existing setup implicitly requires both Apache Commons lang 2 and 3, this broke RBS's client test project when it stopped (transitively) pulling in commons lang 2.