### PR TITLE
DC-345: Add server configuration property for the rawls service

### DIFF
--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -55,6 +55,10 @@ public class ServerSpecification implements SpecificationInterface {
   @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   public String catalogUri;
 
+  // Rawls Service
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  public String rawlsUri;
+
   // =============================================
   // Cluster & deployment: information required to manipulate Kubernetes and deploy
   // Kubernetes cluster specification


### PR DESCRIPTION
The catalog service depends on the Rawls service (https://github.com/broadinstitute/rawls) and needs a configurable property in `ServerSpecification` to write integration tests against this service.