### PR TITLE
Enable catalogUri and extraCredentialsManagerUri properties to be included in json outputs.

### DIFF
--- a/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/ServerSpecification.java
@@ -44,7 +44,6 @@ public class ServerSpecification implements SpecificationInterface {
   public String workspaceManagerUri;
 
   // External Credentials Manager
-  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   public String externalCredentialsManagerUri;
 
   // Drs Hub
@@ -52,7 +51,6 @@ public class ServerSpecification implements SpecificationInterface {
   public String drsHubUri;
 
   // Catalog Service
-  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   public String catalogUri;
 
   // Rawls Service


### PR DESCRIPTION
Doesn't need a version bump as it does not affect tests using the current version.