### PR TITLE
QA-1914: Enable a test script to retry a number of times through configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ The scaling specification includes:
 
 * Number of different users making the User Journey calls.
 
+Retry settings (0.1.6-SNAPSHOT):
+
+* Added `maxRetries` and `timeToWait` properties.
+  * `maxRetries`: maximum number of retries per user journey thread (default: 3)
+  * `timeToWait`: wait time (milliseconds) till next retry (default: 2000 ms)
+
 The application specification includes (this section applies to resiliency test
 type)
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.1.5-SNAPSHOT'
+version '0.1.6-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')

--- a/src/main/java/bio/terra/testrunner/runner/RetryLogic.java
+++ b/src/main/java/bio/terra/testrunner/runner/RetryLogic.java
@@ -33,7 +33,16 @@ public class RetryLogic {
   }
 
   public void waitForNextRetry() throws Exception {
-    logger.info("Sleeping for {} milliseconds before exit or next retry.", timeToWait);
+    if (retryAttempts < maxRetries)
+      logger.info(
+          "{} retry attempt(s) left. Waiting for {} milliseconds before exiting or next retry.",
+          maxRetries - retryAttempts,
+          timeToWait);
+    else
+      logger.info(
+          "Used all {} retry attempts. Waiting for {} milliseconds before exiting.",
+          maxRetries,
+          timeToWait);
     TimeUnit.MILLISECONDS.sleep(timeToWait);
   }
 

--- a/src/main/java/bio/terra/testrunner/runner/RetryLogic.java
+++ b/src/main/java/bio/terra/testrunner/runner/RetryLogic.java
@@ -33,6 +33,6 @@ public class RetryLogic {
 
   @FunctionalInterface
   interface RetryImpl {
-    Boolean run() throws Exception;
+    void run() throws Exception;
   }
 }

--- a/src/main/java/bio/terra/testrunner/runner/RetryLogic.java
+++ b/src/main/java/bio/terra/testrunner/runner/RetryLogic.java
@@ -1,0 +1,38 @@
+package bio.terra.testrunner.runner;
+
+import java.util.concurrent.TimeUnit;
+
+public class RetryLogic {
+  private int maxRetries;
+  private int retryAttempts;
+  private long timeToWait;
+
+  public RetryLogic(int maxRetries, long timeToWait) {
+    this.maxRetries = maxRetries;
+    this.retryAttempts = 0;
+    this.timeToWait = timeToWait;
+  }
+
+  public void retry(RetryImpl retryImpl) throws Exception {
+    if (shouldRetry()) {
+      retryAttempts++;
+      retryImpl.run();
+      waitForNextRetry();
+    } else {
+      throw new Exception(String.format("Failed after %s retry attempt(s).", retryAttempts));
+    }
+  }
+
+  public boolean shouldRetry() {
+    return retryAttempts < maxRetries;
+  }
+
+  public void waitForNextRetry() throws Exception {
+    TimeUnit.MILLISECONDS.sleep(timeToWait);
+  }
+
+  @FunctionalInterface
+  interface RetryImpl {
+    Boolean run() throws Exception;
+  }
+}

--- a/src/main/java/bio/terra/testrunner/runner/RetryLogic.java
+++ b/src/main/java/bio/terra/testrunner/runner/RetryLogic.java
@@ -1,8 +1,12 @@
 package bio.terra.testrunner.runner;
 
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RetryLogic {
+  private static final Logger logger = LoggerFactory.getLogger(RetryLogic.class);
+
   private int maxRetries;
   private int retryAttempts;
   private long timeToWait;
@@ -16,6 +20,7 @@ public class RetryLogic {
   public void retry(RetryImpl retryImpl) throws Exception {
     if (shouldRetry()) {
       retryAttempts++;
+      logger.info("Retry attempt {}.", retryAttempts);
       retryImpl.run();
       waitForNextRetry();
     } else {
@@ -28,6 +33,7 @@ public class RetryLogic {
   }
 
   public void waitForNextRetry() throws Exception {
+    logger.info("Sleeping for {} milliseconds before exit or next retry.", timeToWait);
     TimeUnit.MILLISECONDS.sleep(timeToWait);
   }
 

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -440,6 +440,8 @@ public class TestRunner {
       RetryLogic retryLogic) {
     try {
       testScript.userJourney(testUser);
+      // The exceptionWasThrown property keeps track of whether exceptions were thrown in the last
+      // attempt.
       result.exceptionWasThrown = false;
     } catch (Throwable ex) {
       try {

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -431,6 +431,8 @@ public class TestRunner {
     }
   }
 
+  // Retry logic config applies only to user journey threads.
+  // Test setup / cleanup task runs only once.
   private static void tryDoUserJourney(
       TestScript testScript,
       TestUserSpecification testUser,
@@ -438,21 +440,22 @@ public class TestRunner {
       RetryLogic retryLogic) {
     try {
       testScript.userJourney(testUser);
+      result.exceptionWasThrown = false;
     } catch (Throwable ex) {
       try {
+        result.saveExceptionThrown(ex);
+        result.retryAttempts++;
         retryLogic.retry(
             () -> {
               try {
                 tryDoUserJourney(testScript, testUser, result, retryLogic);
               } catch (Exception userJourneyEx) {
-                result.retryAttempts++;
                 result.saveExceptionThrown(userJourneyEx);
               }
             });
       } catch (Exception retryInterrupted) {
         result.saveExceptionThrown(retryInterrupted);
       }
-      result.saveExceptionThrown(ex);
     }
   }
 

--- a/src/main/java/bio/terra/testrunner/runner/TestRunner.java
+++ b/src/main/java/bio/terra/testrunner/runner/TestRunner.java
@@ -448,7 +448,6 @@ public class TestRunner {
                 result.retryAttempts++;
                 result.saveExceptionThrown(userJourneyEx);
               }
-              return null;
             });
       } catch (Exception retryInterrupted) {
         result.saveExceptionThrown(retryInterrupted);

--- a/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
+++ b/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
@@ -3,6 +3,7 @@ package bio.terra.testrunner.runner;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import org.apache.commons.lang.StringUtils;
 
 @SuppressFBWarnings(
     value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
@@ -18,6 +19,7 @@ public class UserJourneyResult {
   public boolean exceptionWasThrown;
   public String exceptionStackTrace;
   public String exceptionMessage;
+  public int retryAttempts = 0;
 
   public UserJourneyResult() {}
 
@@ -38,7 +40,10 @@ public class UserJourneyResult {
    */
   public void saveExceptionThrown(Throwable exceptionThrown) {
     exceptionWasThrown = true;
-    exceptionMessage = exceptionThrown.getMessage();
+    exceptionMessage =
+        StringUtils.isBlank(exceptionMessage)
+            ? exceptionThrown.getMessage()
+            : String.format("%s\n%s", exceptionMessage, exceptionThrown.getMessage());
 
     StringWriter stackTraceStr = new StringWriter();
     exceptionThrown.printStackTrace(new PrintWriter(stackTraceStr));

--- a/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
+++ b/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
@@ -43,7 +43,7 @@ public class UserJourneyResult {
     exceptionMessage =
         StringUtils.isBlank(exceptionMessage)
             ? exceptionThrown.getMessage()
-            : String.format("%s\n%s", exceptionMessage, exceptionThrown.getMessage());
+            : String.format("%s%n%s", exceptionMessage, exceptionThrown.getMessage());
 
     StringWriter stackTraceStr = new StringWriter();
     exceptionThrown.printStackTrace(new PrintWriter(stackTraceStr));

--- a/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
+++ b/src/main/java/bio/terra/testrunner/runner/config/TestConfiguration.java
@@ -1,6 +1,7 @@
 package bio.terra.testrunner.runner.config;
 
 import bio.terra.testrunner.common.utils.FileUtils;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
@@ -26,6 +27,12 @@ public class TestConfiguration implements SpecificationInterface {
   public List<TestScriptSpecification> testScripts;
   public List<TestUserSpecification> testUsers = new ArrayList<>();
   public DisruptiveScriptSpecification disruptiveScript;
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  public int maxRetries = 3; // default = 3 retries
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  public long timeToWait = 2000; // default = 2000 ms
 
   public static final String resourceDirectory = "configs";
   public static final String serverFileEnvironmentVarName = "TEST_RUNNER_SERVER_SPECIFICATION_FILE";


### PR DESCRIPTION
**Summary**

Provide a way to automatically retry a testrunner test on a failed run. The `TestConfiguration` accepts two new properties: `maxRetries`, `timeToWait` with default values 3 and 2000ms, respectively.

**Context & Background**

Tests have been failing flakily when using SAM dev, due to a connection timeout error. The errors are inside services our tests call, not in calls to SAM directly, and in some cases occur inside flights, so it's hard to add retries within the test to fix this. 

This ticket is to provide a retry configuration. Each test script thread will continue to run a specified number of times on error according to the new configuration. 

**A/C**

Test runner framework will retry a test when error occurs and record the number of retries.