### PR TITLE
[PF-1731] Replace Java setup action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,9 +18,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up AdoptOpenJDK 11
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2


### PR DESCRIPTION
The `joschi/setup-jdk@v2` Github action is deprecated and the recommendation is to move to the official github setup-java action with the `temurin` distribution: see https://github.com/joschi/setup-jdk#-notice