### PR TITLE
Update Kubernetes Client API version to match release 1.24.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 group 'bio.terra'
-version '0.1.6-SNAPSHOT'
+version '0.1.7-SNAPSHOT'
 
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
@@ -44,7 +44,7 @@ dependencies {
         apacheLang = '3.12.0'
         findbugsAnnotations = "3.0.1"
         jackson = '2.11.3'
-        kubernetesClient = '10.0.0'
+        kubernetesClient = '16.0.0'
         logback = '1.2.3'
         slf4j = '1.7.30'
 

--- a/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
+++ b/src/main/java/bio/terra/testrunner/common/utils/KubernetesClientUtils.java
@@ -312,7 +312,7 @@ public final class KubernetesClientUtils {
     // Get the Terra Component Version ConfigMap for the namespace.
     V1ConfigMap config =
         getKubernetesClientCoreObject()
-            .readNamespacedConfigMap("terra-component-version", namespace, null, null, null);
+            .readNamespacedConfigMap("terra-component-version", namespace, null);
     Map<String, String> configMap = config.getData();
     return configMap.entrySet().stream()
         .collect(
@@ -382,11 +382,12 @@ public final class KubernetesClientUtils {
     if (namespace == null || namespace.isEmpty()) {
       list =
           getKubernetesClientCoreObject()
-              .listPodForAllNamespaces(null, null, null, null, null, null, null, null, null);
+              .listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null);
     } else {
       list =
           getKubernetesClientCoreObject()
-              .listNamespacedPod(namespace, null, null, null, null, null, null, null, null, null);
+              .listNamespacedPod(
+                  namespace, null, null, null, null, null, null, null, null, null, null);
     }
     return list.getItems();
   }
@@ -403,12 +404,13 @@ public final class KubernetesClientUtils {
     if (namespace == null || namespace.isEmpty()) {
       list =
           getKubernetesClientAppsObject()
-              .listDeploymentForAllNamespaces(null, null, null, null, null, null, null, null, null);
+              .listDeploymentForAllNamespaces(
+                  null, null, null, null, null, null, null, null, null, null);
     } else {
       list =
           getKubernetesClientAppsObject()
               .listNamespacedDeployment(
-                  namespace, null, null, null, null, null, null, null, null, null);
+                  namespace, null, null, null, null, null, null, null, null, null, null);
     }
     return list.getItems();
   }
@@ -470,7 +472,8 @@ public final class KubernetesClientUtils {
             deployment,
             null,
             null,
-            null);
+            null,
+            "Warn");
   }
 
   /** Select any pod from api pods and delete pod. */

--- a/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
+++ b/src/main/java/bio/terra/testrunner/runner/UserJourneyResult.java
@@ -3,7 +3,7 @@ package bio.terra.testrunner.runner;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @SuppressFBWarnings(
     value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",


### PR DESCRIPTION
The Kubernetes Client version has not been updated for a while. This PR updates the client version to match release 1.24. This will resolve issues for any tests that depends on release 1.24 environment.