### PR TITLE
[PF-1545] Add support for M1 Macs (arm64) in artifact publish script

### DIFF
--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -2,12 +2,17 @@
 # Copied from Terra Resource Buffer service
 # Publish Test Runner client library:
 VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
-DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:consul-0.20.0
+
+# Images built for arm64 platform are required to run this script on M1 Mac (arm64)
+# pick recent stable image from https://hub.docker.com/r/broadinstitute/dsde-toolbox/tags
+# original tag 'consul-0.20.0' built only for amd64
+IMAGE_TAG=master # built for both amd64 & arm64
+DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:${IMAGE_TAG}
 ARTIFACTORY_ACCOUNT_PATH=secret/dsp/accts/artifactory/dsdejenkins
 
-export ARTIFACTORY_USERNAME=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+export ARTIFACTORY_USERNAME=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN --platform linux/amd64 ${DSDE_TOOLBOX_DOCKER_IMAGE} \
  vault read -field username ${ARTIFACTORY_ACCOUNT_PATH})
-export ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+export ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN --platform linux/amd64 ${DSDE_TOOLBOX_DOCKER_IMAGE} \
  vault read -field password ${ARTIFACTORY_ACCOUNT_PATH})
 ./gradlew clean
 ./gradlew spotlessCheck spotbugsMain test


### PR DESCRIPTION
Add support for M1 Macs (arm64) in artifact publish script

Changes were tested with local run

```
BUILD SUCCESSFUL in 5s
12 actionable tasks: 12 executed
[pool-4-thread-1] Deploying artifact: https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/bio/terra/terra-test-runner/0.1.8-SNAPSHOT/terra-test-runner-0.1.8-SNAPSHOT.jar
[pool-4-thread-1] Deploying artifact: https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/bio/terra/terra-test-runner/0.1.8-SNAPSHOT/terra-test-runner-0.1.8-SNAPSHOT.module
[pool-4-thread-1] Deploying artifact: https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/bio/terra/terra-test-runner/0.1.8-SNAPSHOT/terra-test-runner-0.1.8-SNAPSHOT.pom

> Task :artifactoryDeploy
Deploying build info...
Build-info successfully deployed. Browse it in Artifactory under https://broadinstitute.jfrog.io/broadinstitute/webapp/builds/terra-test-runner/1664407165566

BUILD SUCCESSFUL in 6s
14 actionable tasks: 6 executed, 8 up-to-date
```
