### PR TITLE
[TERRA-434] Replace deprecated commands in GH actions & workflows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3


### PR DESCRIPTION
Replace deprecated commands in GH actions & workflows.

- use actions/setup-java@v3 instead of v2
- use actions/checkout@v3 instead of v2
- use actions/cache@v3 instead of v2
- use actions/upload-artifact@v3 instead of v2
- use setup-node@v3 instead of v2
- replace 'set-output' command